### PR TITLE
remove combined name for release artifacts

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -16,7 +16,7 @@ jobs:
       files: |
         src/main.yaml
       esphome-version: 2025.12.7
-      combined-name: project-template
+      # combined-name: project-template
       #### Modify above here to match your project ####
 
       release-summary: ${{ github.event.release.body }}


### PR DESCRIPTION
## Summary
- set `combined-name` in publish-firmware workflow to project-specific identifier

## Testing
- not run (workflow-only change)