### PR TITLE
Remove combined name for firmware publish workflow

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -16,7 +16,7 @@ jobs:
       files: |
         src/main.yaml
       esphome-version: 2025.12.7
-      # combined-name: project-template
+      combined-name: guition-esp32-s3-4848s040
       #### Modify above here to match your project ####
 
       release-summary: ${{ github.event.release.body }}

--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -16,7 +16,6 @@ jobs:
       files: |
         src/main.yaml
       esphome-version: 2025.12.7
-      combined-name: guition-esp32-s3-4848s040
       #### Modify above here to match your project ####
 
       release-summary: ${{ github.event.release.body }}


### PR DESCRIPTION
## Summary
- add project-specific `combined-name` to publish-firmware workflow for release artifacts

## Testing
- not run (workflow-only change)