### PR TITLE
Entity-Konfiguration verbessert

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -204,6 +204,8 @@ number:
   - platform: template
     id: display_timeout_backlight
     name: Hintergrundbeleuchtungs Timeout
+    entity_category: "config"
+    device_class: "duration"
     icon: "mdi:timer"
     optimistic: true
     unit_of_measurement: "m"


### PR DESCRIPTION
## Änderungen

### Display Timeout Number-Component
- `entity_category: "config"` hinzugefügt für bessere Home Assistant Integration
- `device_class: "duration"` hinzugefügt für korrekte Darstellung als Zeitdauer

## Details

Die Display Timeout Number-Component wurde um wichtige Metadaten erweitert:
- **Entity Category**: Kennzeichnet die Entität als Konfigurationselement in Home Assistant
- **Device Class**: Sorgt für korrekte Darstellung und Handling als Zeitdauer

Dies verbessert die Integration mit Home Assistant und macht die Benutzeroberfläche konsistenter.