### PR TITLE
feat: Neustart- und Update-Check-Buttons hinzufügen

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -280,6 +280,25 @@ sensor:
       - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);
     unit_of_measurement: "%"
 
+# Buttons for Restart and Firmware Update
+button:
+  - platform: restart
+    name: "Neustart"
+    id: restart_button
+    entity_category: config
+    icon: "mdi:restart"
+    disabled_by_default: true
+
+  - platform: template
+    name: "Check for Updates"
+    id: check_updates_button
+    entity_category: config
+    icon: "mdi:update"
+    disabled_by_default: true
+    on_press:
+      then:
+        - component.update: firmware_update
+
 # Diagnostic Text Sensors    
 text_sensor:
   # WiFi Info

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -285,14 +285,14 @@ button:
   - platform: restart
     name: "Neustart"
     id: restart_button
-    entity_category: config
+    entity_category: "config"
     icon: "mdi:restart"
     disabled_by_default: true
 
   - platform: template
     name: "Check for Updates"
     id: check_updates_button
-    entity_category: config
+    entity_category: "config"
     icon: "mdi:update"
     disabled_by_default: true
     on_press:


### PR DESCRIPTION
## Zusammenfassung

Fügt zwei praktische Buttons zur Geräteverwaltung hinzu, die standardmäßig deaktiviert sind.

## Änderungen

### `src/common/core.yaml`
- **Neustart-Button**: Ermöglicht das Neustarten des Geräts über Home Assistant
- **Check for Updates-Button**: Löst manuell einen Firmware-Update-Check aus

## Details

| Button | Plattform | Funktion |
|--------|-----------|----------|
| Neustart | `restart` | Startet das ESP32 neu |
| Check for Updates | `template` | Ruft `component.update: firmware_update` auf |

Beide Buttons sind:
- `entity_category: config` → Im Konfigurationsbereich in HA
- `disabled_by_default: true` → Müssen explizit aktiviert werden

## Warum disabled_by_default?

Diese Buttons sind für Wartungszwecke gedacht und sollten nicht versehentlich gedrückt werden. Benutzer können sie bei Bedarf in Home Assistant aktivieren.