### PR TITLE
feat: Add internal 240V relay switch

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -252,6 +252,7 @@ switch:
       number: 40
       mode:
         output: true
+    restore_mode: RESTORE_DEFAULT_OFF
     id: panel_output
     name: "Internes 240V Relais"
     icon: mdi:electric-switch

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -246,7 +246,10 @@ switch:
 
   # Built in 240v relay
   - platform: gpio
-    pin: 40
+    pin:
+      number: 40
+      mode:
+        output: true
     id: panel_output
     name: "Internes 240V Relais"
     icon: mdi:electric-switch

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -245,6 +245,8 @@ switch:
             - lvgl.widget.redraw:
 
   # Built in 240v relay
+  # Relay is currently assumed to be active-high (HIGH = relay ON, LOW = relay OFF).
+  # If your relay module is active-low, update this pin configuration to include `inverted: true`.
   - platform: gpio
     pin:
       number: 40

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -218,8 +218,9 @@ number:
     step: 1
     mode: box
 
-# Antiburn Switch
+# Device Switches
 switch:
+  # Antiburn Switch
   - platform: template
     name: Bildschirmschoner
     id: switch_antiburn
@@ -242,6 +243,13 @@ switch:
           then:
             - lvgl.resume:
             - lvgl.widget.redraw:
+
+  # Built in 240v relay
+  - platform: gpio
+    pin: 40
+    id: panel_output
+    name: "Internes 240V Relais"
+    icon: mdi:electric-switch
 
 # Diagnostic Sensors
 sensor:


### PR DESCRIPTION
## Beschreibung

Fügt Unterstützung für das eingebaute 240V-Relais auf dem Display-Board hinzu.

## Änderungen

- ✅ GPIO40 Relay-Schalter hinzugefügt
- ✅ Konfiguration als "Internes 240V Relais"
- ✅ Verbesserte Strukturierung der Switch-Sektion mit Kommentaren
- ✅ Relay kann über Home Assistant gesteuert werden

## Technische Details

- **Pin**: GPIO40
- **Icon**: `mdi:electric-switch`
- **Typ**: GPIO-Switch

## Testing

- [ ] Firmware kompiliert erfolgreich
- [ ] CI Pipeline durchlaufen
- [ ] Funktionstest auf Hardware

## Dateien

- [src/common/core.yaml](src/common/core.yaml): Relay-Konfiguration hinzugefügt