### PR TITLE
chore: improve OTA UI handling and local dev source

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -4,6 +4,16 @@ globals:
     type: int
     restore_value: yes
     initial_value: '2'
+  
+  - id: ota_active
+    type: bool
+    restore_value: no
+    initial_value: 'false'
+
+  - id: ota_progress
+    type: int
+    restore_value: no
+    initial_value: '0'
 
 # Basic ESPHome Configuration
 esphome:
@@ -20,7 +30,12 @@ esphome:
     - helper/mdi_icon_map.h # MDI Icon Helper für dynamische Icon-Konvertierung aus Home Assistant
   platformio_options:
     board_build.flash_mode: dio    
-
+  on_boot:
+    - priority: -100
+      then:
+        - lambda: |-
+            id(ota_active) = false;
+            id(ota_progress) = 0;
 # ESP32-S3 Specific Configuration
 esp32:
   board: esp32-s3-devkitc-1
@@ -71,6 +86,13 @@ touchscreen:
     mirror_y: false
   display: ${display_name}
   on_release:
+      - if:
+          condition:
+            lambda: 'return id(ota_active);'
+          then:
+            - logger.log: "Touch ignored (OTA active)"
+          else:
+            - logger.log: "Touch processed"
       - if:
           condition: lvgl.is_paused
           then:
@@ -364,8 +386,60 @@ api:
 ota:
   - platform: esphome
     id: ota_state
+    on_begin:
+      then:
+        - lambda: |-
+            id(ota_active) = true;
+            id(ota_progress) = 0;
+        - light.turn_on: display_backlight
+        - lvgl.page.show: ota_page
+
+    on_progress:
+      then:
+        - lambda: |-
+            id(ota_progress) = x;
+        - lvgl.bar.update:
+            id: ota_bar
+            value: !lambda "return id(ota_progress);"
+        - lvgl.label.update:
+            id: ota_percent
+            text: !lambda |-
+              char buf[8];
+              snprintf(buf, sizeof(buf), "%d %%", id(ota_progress));
+              return std::string(buf);
+
+    on_end:
+      then:
+        - lvgl.label.update:
+            id: ota_title
+            text: "Update abgeschlossen"
+        - lvgl.label.update:
+            id: ota_percent
+            text: "Neustart..."
+
+    on_error:
+      then:
+        - lvgl.label.update:
+            id: ota_title
+            text: "Update FEHLER"
+        - lvgl.label.update:
+            id: ota_percent
+            text: "Abgebrochen"
+  
   - platform: http_request
     id: firmware_ota
+    on_begin:
+      then:
+        - script.execute: http_ota_progress_simulation
+    on_error:
+      then:
+        - lvgl.page.show: ota_page
+        - lvgl.label.update:
+            id: ota_title
+            text: "Update FEHLER"
+        - lvgl.label.update:
+            id: ota_percent
+            text: "Abgebrochen"
 
 # HTTP Request Configuration for Firmware Updates
 http_request:

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -438,6 +438,7 @@ ota:
             condition: lvgl.is_paused
             then:
               - lvgl.resume:
+              - lvgl.widget.redraw:
         - lvgl.page.show: ota_page
         - lvgl.label.update:
             id: ota_title

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -94,14 +94,14 @@ touchscreen:
           - logger.log: "Touch ignored (OTA active)"
         else:
           - logger.log: "Touch processed"
-    - if:
-        condition: lvgl.is_paused
-        then:
-          - logger.log: "LVGL resuming"
-          - switch.turn_off: switch_antiburn
-          - lvgl.resume:
-          - lvgl.widget.redraw:
-          - light.turn_on: display_backlight
+          - if:
+              condition: lvgl.is_paused
+              then:
+                - logger.log: "LVGL resuming"
+                - switch.turn_off: switch_antiburn
+                - lvgl.resume:
+                - lvgl.widget.redraw:
+                - light.turn_on: display_backlight
 
 # SPI Bus for Display
 spi:
@@ -415,6 +415,7 @@ ota:
         - lvgl.label.update:
             id: ota_percent
             text: "Neustart..."
+        - lambda: 'id(ota_active) = false;' 
     on_error:
       then:
         - lambda: 'id(ota_active) = false;'
@@ -475,6 +476,7 @@ ota:
             id: ota_percent
             text: "Neustart..."
         - lvgl.widget.redraw:
+        - lambda: 'id(ota_active) = false;' 
     on_error:
       then:
         - lambda: 'id(ota_active) = false;'

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -502,7 +502,7 @@ update:
   - platform: http_request
     id: firmware_update
     name: "Firmware"
-    source: http://192.168.178.185:8000/manifest.json
+    source: https://github.com/tntlarsn/guition-esp32-s3-4848s040/releases/latest/download/${display_name}.manifest.json
     device_class: firmware
     update_interval: 24h
     ota_id: firmware_ota

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -36,6 +36,7 @@ esphome:
         - lambda: |-
             id(ota_active) = false;
             id(ota_progress) = 0;
+
 # ESP32-S3 Specific Configuration
 esp32:
   board: esp32-s3-devkitc-1
@@ -86,21 +87,21 @@ touchscreen:
     mirror_y: false
   display: ${display_name}
   on_release:
-      - if:
-          condition:
-            lambda: 'return id(ota_active);'
-          then:
-            - logger.log: "Touch ignored (OTA active)"
-          else:
-            - logger.log: "Touch processed"
-      - if:
-          condition: lvgl.is_paused
-          then:
-            - logger.log: "LVGL resuming"
-            - switch.turn_off: switch_antiburn
-            - lvgl.resume:
-            - lvgl.widget.redraw:
-            - light.turn_on: display_backlight
+    - if:
+        condition:
+          lambda: 'return id(ota_active);'
+        then:
+          - logger.log: "Touch ignored (OTA active)"
+        else:
+          - logger.log: "Touch processed"
+    - if:
+        condition: lvgl.is_paused
+        then:
+          - logger.log: "LVGL resuming"
+          - switch.turn_off: switch_antiburn
+          - lvgl.resume:
+          - lvgl.widget.redraw:
+          - light.turn_on: display_backlight
 
 # SPI Bus for Display
 spi:
@@ -125,7 +126,6 @@ display:
       mirror_x: false
       mirror_y: false
     cs_pin: 39
-      # reset not defined 
     de_pin: 18
     hsync_pin: 16
     vsync_pin: 17
@@ -137,25 +137,9 @@ display:
     pclk_frequency: 12MHz
     pclk_inverted: false
     data_pins:
-      red:
-        - 11         # R1
-        - 12         # R2
-        - 13         # R3
-        - 14         # R4
-        - 0          # R5
-      green:
-        - 8          # G0
-        - 20         # G1
-        - 3          # G2
-        - 46         # G3
-        - 9          # G4
-        - 10         # G5 
-      blue:
-        - 4          # B1
-        - 5          # B2
-        - 6          # B3
-        - 7          # B4
-        - 15         # B5
+      red:   [11, 12, 13, 14, 0]
+      green: [8, 20, 3, 46, 9, 10]
+      blue:  [4, 5, 6, 7, 15]
 
 # LVGL Configuration
 lvgl:
@@ -184,9 +168,9 @@ time:
     id: sntp_time
     timezone: "${timezone}"
     servers:
-     - ntp0.ntp-servers.net
-     - ntp1.ntp-servers.net
-     - ntp2.ntp-servers.net
+      - ntp0.ntp-servers.net
+      - ntp1.ntp-servers.net
+      - ntp2.ntp-servers.net
     on_time:
       - hours: 2,3,4,5
         minutes: 5
@@ -334,6 +318,15 @@ button:
     on_press:
       then:
         - component.update: firmware_update
+  
+  - platform: template
+    name: "Firmware Update installieren"
+    id: install_firmware_update_button
+    entity_category: "config"
+    icon: "mdi:download"
+    on_press:
+      then:
+        - script.execute: start_ota_update
 
 # Diagnostic Text Sensors    
 text_sensor:
@@ -384,6 +377,7 @@ api:
 
 # OTA is required for Over-the-Air updating
 ota:
+  # ESPHome Dashboard OTA
   - platform: esphome
     id: ota_state
     on_begin:
@@ -392,12 +386,18 @@ ota:
             id(ota_active) = true;
             id(ota_progress) = 0;
         - light.turn_on: display_backlight
+        - if:
+            condition: lvgl.is_paused
+            then:
+              - lvgl.resume:
+              - lvgl.widget.redraw:
         - lvgl.page.show: ota_page
-
+        - lvgl.label.update:
+            id: ota_title
+            text: "ESPHome OTA Update"
     on_progress:
       then:
-        - lambda: |-
-            id(ota_progress) = x;
+        - lambda: 'id(ota_progress) = x;'
         - lvgl.bar.update:
             id: ota_bar
             value: !lambda "return id(ota_progress);"
@@ -407,7 +407,6 @@ ota:
               char buf[8];
               snprintf(buf, sizeof(buf), "%d %%", id(ota_progress));
               return std::string(buf);
-
     on_end:
       then:
         - lvgl.label.update:
@@ -416,32 +415,77 @@ ota:
         - lvgl.label.update:
             id: ota_percent
             text: "Neustart..."
-
     on_error:
       then:
+        - lambda: 'id(ota_active) = false;'
         - lvgl.label.update:
             id: ota_title
             text: "Update FEHLER"
         - lvgl.label.update:
             id: ota_percent
             text: "Abgebrochen"
-  
+
+  # HTTP Request OTA (für Firmware Updates via manifest.json)
   - platform: http_request
     id: firmware_ota
     on_begin:
       then:
-        - script.execute: http_ota_progress_simulation
+        - lambda: |-
+            id(ota_active) = true;
+            id(ota_progress) = 0;
+        - light.turn_on: display_backlight
+        - if:
+            condition: lvgl.is_paused
+            then:
+              - lvgl.resume:
+        - lvgl.page.show: ota_page
+        - lvgl.label.update:
+            id: ota_title
+            text: "Firmware Download"
+        - lvgl.label.update:
+            id: ota_percent
+            text: "0 %"
+        - lvgl.bar.update:
+            id: ota_bar
+            value: 0
+        - lvgl.widget.redraw:
+    on_progress:
+      then:
+        - lambda: |-
+            id(ota_progress) = (int)x;
+            lv_task_handler();
+        - lvgl.bar.update:
+            id: ota_bar
+            value: !lambda "return (int)x;"
+        - lvgl.label.update:
+            id: ota_percent
+            text: !lambda |-
+              char buf[8];
+              snprintf(buf, sizeof(buf), "%d %%", (int)x);
+              return std::string(buf);
+        - lambda: 'lv_task_handler();'
+    on_end:
+      then:
+        - lambda: 'id(ota_active) = false;'
+        - lvgl.label.update:
+            id: ota_title
+            text: "Update abgeschlossen"
+        - lvgl.label.update:
+            id: ota_percent
+            text: "Neustart..."
+        - lvgl.widget.redraw:
     on_error:
       then:
-        - lvgl.page.show: ota_page
+        - lambda: 'id(ota_active) = false;'
         - lvgl.label.update:
             id: ota_title
             text: "Update FEHLER"
         - lvgl.label.update:
             id: ota_percent
             text: "Abgebrochen"
+        - lvgl.widget.redraw:
 
-# HTTP Request Configuration for Firmware Updates
+# HTTP Request Configuration
 http_request:
   useragent: esphome-4848s040
   follow_redirects: true
@@ -450,14 +494,45 @@ http_request:
   buffer_size_rx: 2048
   buffer_size_tx: 1024
 
-# Firmware
+# Firmware Update
 update:
   - platform: http_request
     id: firmware_update
     name: "Firmware"
-    source: https://github.com/tntlarsn/guition-esp32-s3-4848s040/releases/latest/download/${display_name}.manifest.json
+    source: http://192.168.178.185:8000/manifest.json
     device_class: firmware
     update_interval: 24h
+    ota_id: firmware_ota
+    on_update_available:
+      then:
+        - logger.log: "Firmware Update verfügbar!"
+
+# Script für OTA Update
+script:
+  - id: start_ota_update
+    mode: single
+    then:
+      - lambda: |-
+          id(ota_active) = true;
+          id(ota_progress) = 0;
+      - light.turn_on: display_backlight
+      - if:
+          condition: lvgl.is_paused
+          then:
+            - lvgl.resume:
+            - lvgl.widget.redraw:
+      - lvgl.page.show: ota_page
+      - lvgl.label.update:
+          id: ota_title
+          text: "Firmware Download"
+      - lvgl.label.update:
+          id: ota_percent
+          text: "Wird gestartet..."
+      - lvgl.bar.update:
+          id: ota_bar
+          value: 0
+      - delay: 500ms
+      - update.perform: firmware_update
 
 # WiFi Configuration
 wifi:

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -4,6 +4,7 @@ packages:
   homeassistant: !include common/homeassistant.yaml
   boot_screen: !include pages/boot.yaml
   home_page: !include pages/home.yaml
+  ota_page: !include pages/ota.yaml
   theme: !include themes/homeassistant.yaml
 
 substitutions: !include common/substitutions.yaml

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -1,0 +1,67 @@
+############################
+# LVGL OTA PAGE (OVERLAY)
+############################
+lvgl:
+  pages:
+    - id: ota_page
+      widgets:
+        - obj:
+            width: 100%
+            height: 100%
+            bg_color: 0x000000
+            bg_opa: 80%
+
+            widgets:
+              - label:
+                  id: ota_title
+                  text: "Firmware Update"
+                  align: TOP_MID
+                  y: 20
+                  text_font: montserrat_24
+
+              - bar:
+                  id: ota_bar
+                  width: 80%
+                  height: 30
+                  align: CENTER
+                  min_value: 0
+                  max_value: 100
+                  value: 0
+
+              - label:
+                  id: ota_percent
+                  text: "0 %"
+                  align: CENTER
+                  y: 40
+                  text_font: montserrat_20
+
+############################
+# HTTP REQUEST OTA (UX PROGRESS)
+############################
+script:
+  - id: http_ota_progress_simulation
+    mode: restart
+    then:
+      - lambda: |-
+          id(ota_active) = true;
+          id(ota_progress) = 0;
+      - light.turn_on: display_backlight
+      - lvgl.page.show: ota_page
+      - lvgl.label.update:
+          id: ota_title
+          text: "Firmware Download"
+      - repeat:
+          count: 100
+          then:
+            - delay: 300ms
+            - lambda: |-
+                id(ota_progress) += 1;
+            - lvgl.bar.update:
+                id: ota_bar
+                value: !lambda "return id(ota_progress);"
+            - lvgl.label.update:
+                id: ota_percent
+                text: !lambda |-
+                  char buf[8];
+                  snprintf(buf, sizeof(buf), "%d %%", id(ota_progress));
+                  return std::string(buf);

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -37,14 +37,14 @@ lvgl:
                         text: "Firmware Update"
                         align: top_mid
                         y: 0
-                        text_font: montserrat_24
+                        text_font: nunito_20
                         text_color: color_text_dark_primary
 
                     - bar:
                         id: ota_bar
                         width: 100%
                         height: 30
-                        align: CENTER
+                        align: center
                         y: 20
                         min_value: 0
                         max_value: 100
@@ -53,7 +53,7 @@ lvgl:
                     - label:
                         id: ota_percent
                         text: "0 %"
-                        align: CENTER
+                        align: center
                         y: 60
-                        text_font: montserrat_20
+                        text_font: nunito_20
                         text_color: color_text_dark_primary

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -1,67 +1,59 @@
 ############################
-# LVGL OTA PAGE (OVERLAY)
+# LVGL OTA PAGE
 ############################
 lvgl:
   pages:
     - id: ota_page
       widgets:
         - obj:
-            width: 100%
-            height: 100%
-            bg_color: 0x000000
-            bg_opa: 80%
-
+            bg_color: color_surface_dark
+            shadow_opa: transp
+            width: ${display_width}
+            height: ${display_height}
+            outline_width: 0
+            border_width: 0
+            radius: 0
             widgets:
-              - label:
-                  id: ota_title
-                  text: "Firmware Update"
-                  align: TOP_MID
-                  y: 20
-                  text_font: montserrat_24
+              - image:
+                  y: 30
+                  align: top_mid
+                  src: ha_img
 
-              - bar:
-                  id: ota_bar
-                  width: 80%
-                  height: 30
-                  align: CENTER
-                  min_value: 0
-                  max_value: 100
-                  value: 0
+              - obj:
+                  id: ota_container
+                  y: 180
+                  width: 300
+                  height: 200
+                  pad_all: 0
+                  align: top_mid
+                  bg_opa: transp
+                  shadow_opa: transp
+                  border_opa: transp
+                  border_width: 0
+                  radius: 10
+                  widgets:
+                    - label:
+                        id: ota_title
+                        text: "Firmware Update"
+                        align: TOP_MID
+                        y: 0
+                        text_font: montserrat_24
+                        text_color: color_text_dark_primary
 
-              - label:
-                  id: ota_percent
-                  text: "0 %"
-                  align: CENTER
-                  y: 40
-                  text_font: montserrat_20
+                    - bar:
+                        id: ota_bar
+                        width: 100%
+                        height: 30
+                        align: CENTER
+                        y: 20
+                        min_value: 0
+                        max_value: 100
+                        value: 0
 
-############################
-# HTTP REQUEST OTA (UX PROGRESS)
-############################
-script:
-  - id: http_ota_progress_simulation
-    mode: restart
-    then:
-      - lambda: |-
-          id(ota_active) = true;
-          id(ota_progress) = 0;
-      - light.turn_on: display_backlight
-      - lvgl.page.show: ota_page
-      - lvgl.label.update:
-          id: ota_title
-          text: "Firmware Download"
-      - repeat:
-          count: 100
-          then:
-            - delay: 300ms
-            - lambda: |-
-                id(ota_progress) += 1;
-            - lvgl.bar.update:
-                id: ota_bar
-                value: !lambda "return id(ota_progress);"
-            - lvgl.label.update:
-                id: ota_percent
-                text: !lambda |-
-                  char buf[8];
-                  snprintf(buf, sizeof(buf), "%d %%", id(ota_progress));
-                  return std::string(buf);
+                    - label:
+                        id: ota_percent
+                        text: "0 %"
+                        align: CENTER
+                        y: 60
+                        text_font: montserrat_20
+                        text_color: color_text_dark_primary

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -35,7 +35,7 @@ lvgl:
                     - label:
                         id: ota_title
                         text: "Firmware Update"
-                        align: TOP_MID
+                        align: top_mid
                         y: 0
                         text_font: montserrat_24
                         text_color: color_text_dark_primary


### PR DESCRIPTION
## Änderungen
- Verfeinert OTA-Statushandling (ESPHome OTA + HTTP OTA) mit sichtbarem Fortschritt in der LVGL-Oberfläche
- Touch-Eingaben während OTA pausiert und Backlight/Resume-Logik integriert
- Kleinere Format- und Konsistenzanpassungen (Display-Pins, NTP-Server-Indents)

## Dateien
- [src/common/core.yaml](src/common/core.yaml)
- [src/pages/ota.yaml](src/pages/ota.yaml)

## Tests
- [x] esphome config src/main.yaml
- [x] esphome compile src/main.yaml
- [x] Manuelles OTA auf Gerät
