### PR TITLE
feat: Local Dev Mode für iterative OTA-Tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,3 +9,4 @@
 
 # CodeQL artifacts
 _codeql_detected_source_root
+.http_server.pid

--- a/MAKEFILE_GUIDE.md
+++ b/MAKEFILE_GUIDE.md
@@ -1,0 +1,271 @@
+# 🚀 Makefile - Lokale OTA-Update Commands
+
+## Neuen Makefile-Targets
+
+### 🧪 Lokale OTA-Updates (ohne GitHub Release)
+
+#### `make localupdate` - Vollständiger OTA-Test
+
+**Was es tut:**
+1. ✅ Kompiliert Firmware mit `main.yaml`
+2. ✅ Berechnet MD5 & SHA256 Checksummen
+3. ✅ Erstellt `manifest.json` automatisch
+4. ✅ Passt `core.yaml` mit lokaler Update-URL an
+5. ✅ Kompiliert Firmware erneut mit lokaler URL
+6. ✅ Startet HTTP-Server (Port 8000)
+
+**Verwendung:**
+```bash
+make localupdate
+```
+
+**Output:**
+```
+╔════════════════════════════════════════════════════════════╗
+║              🎉 Alles bereit zum OTA-Test! 🎉              ║
+╚════════════════════════════════════════════════════════════╝
+
+✅ FERTIG - Das brauchst du jetzt:
+1️⃣  Starte das Update auf deinem Gerät:
+    Home Assistant → ESPHome → [display01] → Firmware aktualisieren
+...
+```
+
+#### `make localcleanup` - Aufräumen nach dem Test
+
+**Was es tut:**
+1. ✅ Stoppt HTTP-Server
+2. ✅ Restauriert `core.yaml` aus Backup
+3. ✅ Bereinigt temporäre Dateien
+
+**Verwendung:**
+```bash
+make localcleanup
+```
+
+---
+
+### 📦 Release-Management (lokale Versionen)
+
+Verwalte mehrere lokale Firmware-Releases für verschiedene Test-Szenarien.
+
+#### `make releases-list` - Zeige alle Releases
+
+```bash
+make releases-list
+```
+
+**Output Beispiel:**
+```
+═══════════════════════════════════════════════════
+  Lokale Firmware-Releases
+═══════════════════════════════════════════════════
+
+✓ 2026.2.0-local (AKTIV)
+  └─ Erstellt: 2026-01-20T14:32:10Z
+  └─ MD5: 9d9896a0a45a7c8627...
+  └─ Notizen: Version mit neuer LVGL UI
+
+  2026.1.3-local
+  └─ Erstellt: 2026-01-20T13:15:00Z
+  └─ MD5: 24351e744cf605a13ca...
+```
+
+#### `make releases-create` - Neues Release erstellen
+
+```bash
+make releases-create
+```
+
+**Workflow:**
+```
+Erstelle Release: 2026.2.0-local
+Berechne Checksummen...
+
+Gib Release-Notizen ein (optional, oder Enter zum Überspringen):
+> Version mit neuer LVGL UI und Performance-Optimierungen
+
+✅ Release erstellt:
+   Version: 2026.2.0-local
+   OTA MD5: 9d9896a0a45a7c862793e872a2ee2c6d
+   Dieses Release jetzt aktivieren? (j/n): j
+```
+
+#### `make releases-use <version>` - Release aktivieren
+
+Aktiviere ein bestehendes Release für Tests.
+
+```bash
+bash local_release_manager.sh use 2026.1.3-local
+```
+
+**Was passiert:**
+- manifest.json wird mit Checksummen des Releases aktualisiert
+- Versionsnummer wird auf das alte Release gesetzt
+- Bereit für OTA-Tests mit dieser alten Version
+
+#### `make releases-current` - Zeige aktuelles Release
+
+```bash
+make releases-current
+```
+
+**Output:**
+```
+Aktuelles aktives Release:
+2026.2.0-local
+
+  "version": "2026.2.0-local",
+  "timestamp": "2026-01-20T14:32:10Z",
+  "notes": "Version mit neuer LVGL UI",
+  "ota_md5": "9d9896a0a45a7c862793e872a2ee2c6d",
+  ...
+```
+
+---
+
+## 🔄 Beispiel-Workflow
+
+### Szenario: "Alte Version testen, dann auf neue upgraden"
+
+```bash
+# 1. Starte lokales OTA-Setup
+make localupdate
+
+# 2. (Im ESPHome Dashboard) Update durchführen
+# ... Gerät upgraded auf LOCAL_DEV ...
+
+# 3. Nach dem Test: Cleanup
+make localcleanup
+
+# 4. Später: Neues Release erstellen
+make releases-create
+# Gib Version "2026.2.0-local" ein
+# Gib Notizen ein: "Performance-Optimierungen"
+# Aktiviere sofort
+
+# 5. HTTP-Server starten (für neue Version)
+make localupdate
+
+# 6. Im Dashboard: Erneut Update starten
+# ... Gerät upgraded auf 2026.2.0-local ...
+
+# 7. Falls zu Problem führt: Zurück zur alten Version
+bash local_release_manager.sh use 2026.1.3-local
+make localupdate
+# Dashboard → Update → Upgrade auf 2026.1.3-local
+```
+
+---
+
+## 📂 Dateien & Verzeichnisse
+
+```
+src/.esphome/build/display01/
+├── manifest.json                    ← Auto-generiert
+├── firmware.ota.bin                 ← OTA-Firmware
+├── firmware.factory.bin             ← Factory-Firmware
+└── .active_release                  ← Aktuelles Release
+
+.local_releases/
+├── release-2026.1.3-local.json
+├── release-2026.2.0-local.json
+└── ...
+
+src/common/
+├── core.yaml                        ← Angepasst mit lokaler URL
+└── core.yaml.ota-backup            ← Backup für Cleanup
+```
+
+---
+
+## 🛠️ Unter der Haube
+
+### `local_ota_test.sh`
+- Hauptscript für OTA-Setup
+- Bauprozess, Checksummen-Berechnung, Server-Start
+- Erstellt auch automatisch `cleanup_ota_test.sh`
+
+### `local_release_manager.sh`
+- Verwaltet lokale Release-Versionen
+- Speichert Metadaten (Timestamp, Notes, Checksummen)
+- Aktualisiert automatisch manifest.json bei Release-Aktivierung
+
+### `cleanup_ota_test.sh` (Auto-generiert)
+- Stoppt HTTP-Server
+- Restauriert `core.yaml` aus Backup
+- Bereinigt Temp-Dateien
+
+---
+
+## 💡 Tipps & Tricks
+
+### Multi-Version Testing
+
+```bash
+# Teste unterschiedliche Versionen ohne GitHub
+make releases-list
+make releases-use 2026.1.3-local
+make localupdate
+# ... Update durchführen ...
+make localcleanup
+
+make releases-use 2026.2.0-local
+make localupdate
+# ... Upgrade durchführen ...
+```
+
+### Release-Notizen dokumentieren
+
+Nutze beschreibende Notizen um zu tracken, welche Features getestet wurden:
+
+```bash
+make releases-create
+# "OTA-Update-Mechanismus mit LVGL Progress - funktioniert ✓"
+# "MD5-Checksummen-Validierung - OK"
+```
+
+### Netzwerk-Fehler debuggen
+
+```bash
+# Während localupdate läuft:
+tail -f /tmp/http_server.log
+
+# Oder (in separatem Terminal):
+curl -I http://192.168.178.185:8000/manifest.json
+curl -I http://192.168.178.185:8000/firmware.ota.bin
+```
+
+### Server läuft noch?
+
+```bash
+lsof -i :8000
+```
+
+---
+
+## ⚠️ Wichtige Hinweise
+
+1. **core.yaml Backup**: Wird automatisch erstellt als `core.yaml.ota-backup`
+   - Cleanup restauriert diese automatisch
+   - Falls something goes wrong: `cp src/common/core.yaml.ota-backup src/common/core.yaml`
+
+2. **Firewall**: macOS Firewall kann HTTP-Zugriff blockieren
+   ```bash
+   sudo /usr/libexec/ApplicationFirewall/socketfilterfw --setglobalstate off
+   # Nach Test: --setglobalstate on
+   ```
+
+3. **HTTP-Server Port 8000**: Prüfe Verfügbarkeit
+   ```bash
+   lsof -i :8000
+   # Falls belegt: Ändere PORT in local_ota_test.sh
+   ```
+
+4. **Keine Online-Releases**: Das ist nur für lokale Tests!
+   - Production-Releases gehen weiterhin über GitHub
+   - Push, Tag, Release → GitHub Actions buildet automatisch
+
+---
+
+**Frohes Testen! 🚀**

--- a/cleanup_ota_test.sh
+++ b/cleanup_ota_test.sh
@@ -1,0 +1,131 @@
+#!/bin/bash
+
+##############################################################################
+# Local Dev Cleanup - Zurück zum Normalzustand
+# 
+# Workflow:
+# 1. HTTP-Server stoppen
+# 2. core.yaml wiederherstellen
+# 3. Firmware mit GitHub-URL kompilieren
+# 4. Finales OTA-Update zurück zu GitHub-URL
+# 5. State-Datei löschen
+##############################################################################
+
+set -e
+
+# Farben
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Konfiguration
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="${PROJECT_DIR}/.local_dev_state"
+CORE_YAML="${PROJECT_DIR}/src/common/core.yaml"
+HTTP_PORT=8000
+
+echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║          🧹 Local Dev Cleanup                              ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# State laden falls vorhanden
+DEVICE_IP=""
+if [ -f "$STATE_FILE" ]; then
+    source "$STATE_FILE"
+    echo -e "${GREEN}✅ State geladen${NC}"
+    echo "   • Device: $DEVICE_IP"
+    echo ""
+fi
+
+# ============================================================================
+# 1. HTTP-Server stoppen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 1: HTTP-Server stoppen...${NC}"
+
+HTTP_PID=$(lsof -Pi :$HTTP_PORT -sTCP:LISTEN -t 2>/dev/null || true)
+if [ -n "$HTTP_PID" ]; then
+    kill $HTTP_PID 2>/dev/null || true
+    sleep 1
+    echo -e "${GREEN}✅ HTTP-Server gestoppt (PID: $HTTP_PID)${NC}"
+else
+    echo "   → Kein HTTP-Server aktiv"
+fi
+echo ""
+
+# ============================================================================
+# 2. core.yaml update.source wiederherstellen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 2: update.source wiederherstellen...${NC}"
+
+if [ -n "${ORIGINAL_SOURCE_URL:-}" ]; then
+    # Nur die URL ersetzen, Rest der Datei bleibt unverändert
+    sed -i '' "s|source: http://[^/]*/manifest.json|source: $ORIGINAL_SOURCE_URL|g" "$CORE_YAML"
+    echo -e "${GREEN}✅ update.source wiederhergestellt${NC}"
+    echo "   → URL: $ORIGINAL_SOURCE_URL"
+else
+    # Fallback: Standard GitHub-URL verwenden
+    GITHUB_URL='https://github.com/tntlarsn/guition-esp32-s3-4848s040/releases/latest/download/\${display_name}.manifest.json'
+    sed -i '' "s|source: http://[^/]*/manifest.json|source: $GITHUB_URL|g" "$CORE_YAML"
+    echo -e "${GREEN}✅ update.source auf GitHub-URL zurückgesetzt${NC}"
+fi
+echo ""
+
+# ============================================================================
+# 3. Firmware mit GitHub-URL kompilieren
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 3: Firmware kompilieren (GitHub-URL)...${NC}"
+
+cd "$PROJECT_DIR"
+if ! esphome compile src/main.yaml > /tmp/compile.log 2>&1; then
+    echo -e "${RED}❌ Build fehlgeschlagen${NC}"
+    tail -20 /tmp/compile.log
+    exit 1
+fi
+echo -e "${GREEN}✅ Firmware kompiliert${NC}"
+echo ""
+
+# ============================================================================
+# 4. Finales OTA-Update (zurück zu GitHub-URL)
+# ============================================================================
+if [ -n "$DEVICE_IP" ]; then
+    echo -e "${YELLOW}📍 Schritt 4: Firmware auf Gerät flashen...${NC}"
+    echo "   → esphome upload src/main.yaml --device $DEVICE_IP"
+    echo ""
+    
+    if esphome upload src/main.yaml --device "$DEVICE_IP"; then
+        echo ""
+        echo -e "${GREEN}✅ Firmware geflasht${NC}"
+    else
+        echo -e "${YELLOW}⚠️  Flash fehlgeschlagen, manuell ausführen:${NC}"
+        echo "   esphome upload src/main.yaml --device $DEVICE_IP"
+    fi
+else
+    echo -e "${YELLOW}📍 Schritt 4: Manuelles Flash erforderlich${NC}"
+    echo "   esphome upload src/main.yaml --device <DEVICE_IP>"
+fi
+echo ""
+
+# ============================================================================
+# 5. State-Datei löschen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 5: Aufräumen...${NC}"
+
+if [ -f "$STATE_FILE" ]; then
+    rm "$STATE_FILE"
+    echo "   → State-Datei gelöscht"
+fi
+
+# Temporäre Dateien
+rm -f /tmp/compile.log /tmp/http_server.log 2>/dev/null || true
+
+echo ""
+echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║         ✅ Cleanup abgeschlossen!                          ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${GREEN}Das Gerät ist wieder im Normalzustand.${NC}"
+echo "   • Update-URL: GitHub Releases"
+echo ""

--- a/full_local_release_test.sh
+++ b/full_local_release_test.sh
@@ -1,0 +1,229 @@
+#!/bin/bash
+
+##############################################################################
+# Local Dev Mode - Gerät in lokalen Entwicklungsmodus versetzen
+# 
+# Workflow:
+# 1. PC-IP erkennen
+# 2. Device-IP ermitteln
+# 3. core.yaml mit lokaler URL patchen
+# 4. Firmware kompilieren
+# 5. Erstes OTA-Update durchführen (esphome run)
+# 6. HTTP-Server starten
+# 7. Fertig! Gerät ist im lokalen Modus
+#
+# Usage: bash full_local_release_test.sh [device-ip]
+# Beispiel: bash full_local_release_test.sh 192.168.178.150
+##############################################################################
+
+set -e
+
+# Farben
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Konfiguration
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+HTTP_PORT=8000
+DEVICE_IP="${1:-}"
+CORE_YAML="${PROJECT_DIR}/src/common/core.yaml"
+STATE_FILE="${PROJECT_DIR}/.local_dev_state"
+
+echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║          🚀 Local Dev Mode - Setup                         ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# ============================================================================
+# 1. PC-IP automatisch erkennen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 1: PC-IP erkennen...${NC}"
+PC_IP=$(ifconfig | grep -E "inet " | grep -v 127.0.0.1 | head -1 | awk '{print $2}')
+
+if [ -z "$PC_IP" ]; then
+    echo -e "${RED}❌ Konnte PC-IP nicht erkennen${NC}"
+    read -p "   Gib deine PC-IP ein: " PC_IP
+fi
+
+if [ -z "$PC_IP" ]; then
+    echo -e "${RED}❌ PC-IP erforderlich!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ PC-IP: $PC_IP${NC}"
+echo ""
+
+# ============================================================================
+# 2. Device-IP ermitteln
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 2: Device-IP ermitteln...${NC}"
+
+if [ -z "$DEVICE_IP" ]; then
+    # Versuche mDNS
+    DEVICE_IP=$(timeout 2 ping -c 1 display01.local 2>/dev/null | grep -Eo '([0-9]{1,3}\.){3}[0-9]{1,3}' | head -1 || true)
+    
+    if [ -z "$DEVICE_IP" ]; then
+        read -p "   Gib die Device-IP ein (z.B. 192.168.178.150): " DEVICE_IP
+    fi
+fi
+
+if [ -z "$DEVICE_IP" ]; then
+    echo -e "${RED}❌ Device-IP erforderlich!${NC}"
+    exit 1
+fi
+
+echo -e "${GREEN}✅ Device-IP: $DEVICE_IP${NC}"
+echo ""
+
+# ============================================================================
+# 3. core.yaml mit lokaler URL patchen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 3: core.yaml patchen...${NC}"
+
+# Originale URL extrahieren und speichern (nur beim ersten Mal)
+if [ -z "${ORIGINAL_SOURCE_URL:-}" ]; then
+    ORIGINAL_SOURCE_URL=$(grep -E '^\s+source:' "$CORE_YAML" | head -1 | sed 's/.*source: //')
+    echo "   → Originale URL: $ORIGINAL_SOURCE_URL"
+fi
+
+# Ersetze URL mit lokaler URL
+if ! grep -q "source: http://$PC_IP:$HTTP_PORT/manifest.json" "$CORE_YAML"; then
+    sed -i '' "s|source: .*manifest.json|source: http://$PC_IP:$HTTP_PORT/manifest.json|g" "$CORE_YAML"
+    echo -e "${GREEN}✅ core.yaml → lokale URL${NC}"
+else
+    echo "   → Bereits konfiguriert"
+fi
+echo ""
+
+# ============================================================================
+# 4. Firmware kompilieren
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 4: Firmware kompilieren...${NC}"
+
+cd "$PROJECT_DIR"
+if ! esphome compile src/main.yaml > /tmp/compile.log 2>&1; then
+    echo -e "${RED}❌ Build fehlgeschlagen${NC}"
+    tail -20 /tmp/compile.log
+    exit 1
+fi
+echo -e "${GREEN}✅ Firmware kompiliert${NC}"
+echo ""
+
+# ============================================================================
+# 5. Erstes OTA-Update durchführen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 5: Firmware auf Gerät flashen...${NC}"
+echo "   → esphome upload src/main.yaml --device $DEVICE_IP"
+echo ""
+
+if ! esphome upload src/main.yaml --device "$DEVICE_IP"; then
+    echo -e "${RED}❌ Flash fehlgeschlagen${NC}"
+    exit 1
+fi
+
+echo ""
+echo -e "${GREEN}✅ Firmware geflasht, warte auf Reboot...${NC}"
+sleep 10
+echo ""
+
+# ============================================================================
+# 6. HTTP-Server starten + manifest.json erstellen
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 6: HTTP-Server starten...${NC}"
+
+# Build-Verzeichnis
+BUILD_DIR="${PROJECT_DIR}/src/.esphome/build/display01"
+PIOENV_DIR="${BUILD_DIR}/.pioenvs/display01"
+mkdir -p "$BUILD_DIR"
+
+# Firmware-Dateien aus dem PlatformIO Build-Verzeichnis kopieren
+# WICHTIG: Die neuste kompilierte Firmware liegt in .pioenvs/display01/
+if [ -f "${PIOENV_DIR}/firmware.ota.bin" ]; then
+    cp "${PIOENV_DIR}/firmware.ota.bin" "${BUILD_DIR}/firmware.ota.bin"
+    echo "   → firmware.ota.bin kopiert"
+fi
+if [ -f "${PIOENV_DIR}/firmware.factory.bin" ]; then
+    cp "${PIOENV_DIR}/firmware.factory.bin" "${BUILD_DIR}/firmware.factory.bin"
+    echo "   → firmware.factory.bin kopiert"
+fi
+
+# Checksummen berechnen
+OTA_MD5=$(md5sum "${BUILD_DIR}/firmware.ota.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+OTA_SHA256=$(shasum -a 256 "${BUILD_DIR}/firmware.ota.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+FACTORY_MD5=$(md5sum "${BUILD_DIR}/firmware.factory.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+FACTORY_SHA256=$(shasum -a 256 "${BUILD_DIR}/firmware.factory.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+
+# manifest.json erstellen
+cat > "${BUILD_DIR}/manifest.json" << EOF
+{
+  "name": "tnt_larsn.esphome_display",
+  "version": "LOCAL_DEV",
+  "home_assistant_domain": "esphome",
+  "new_install_prompt_erase": false,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "ota": {
+        "path": "firmware.ota.bin",
+        "md5": "$OTA_MD5",
+        "sha256": "$OTA_SHA256",
+        "summary": "🧪 Local Dev Build",
+        "release_url": "http://$PC_IP:$HTTP_PORT/firmware.ota.bin"
+      },
+      "parts": [
+        {
+          "path": "firmware.factory.bin",
+          "offset": 0,
+          "md5": "$FACTORY_MD5",
+          "sha256": "$FACTORY_SHA256"
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+# HTTP-Server starten (falls nicht bereits läuft)
+if ! lsof -Pi :$HTTP_PORT -sTCP:LISTEN -t >/dev/null 2>&1; then
+    cd "$BUILD_DIR"
+    python3 -m http.server $HTTP_PORT > /tmp/http_server.log 2>&1 &
+    HTTP_PID=$!
+    sleep 2
+    echo -e "${GREEN}✅ HTTP-Server gestartet (PID: $HTTP_PID)${NC}"
+else
+    HTTP_PID=$(lsof -Pi :$HTTP_PORT -sTCP:LISTEN -t | head -1)
+    echo "   → HTTP-Server läuft bereits (PID: $HTTP_PID)"
+fi
+
+# State speichern (inkl. originaler URL für Cleanup)
+# WICHTIG: Einfache Anführungszeichen für ORIGINAL_SOURCE_URL um ${display_name} literal zu erhalten!
+echo "PC_IP=$PC_IP" > "$STATE_FILE"
+echo "DEVICE_IP=$DEVICE_IP" >> "$STATE_FILE"
+echo "HTTP_PID=$HTTP_PID" >> "$STATE_FILE"
+echo "HTTP_PORT=$HTTP_PORT" >> "$STATE_FILE"
+echo 'ORIGINAL_SOURCE_URL='"'$ORIGINAL_SOURCE_URL'" >> "$STATE_FILE"
+
+echo ""
+echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║         🎉 Local Dev Mode AKTIV!                           ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${GREEN}Das Gerät ist jetzt im lokalen Entwicklungsmodus!${NC}"
+echo ""
+echo -e "${YELLOW}📝 Iterativer Workflow:${NC}"
+echo "   1. Code ändern (z.B. src/pages/home.yaml)"
+echo "   2. make localupdate"
+echo "   3. Home Assistant → ESPHome → display01 → 'Update'"
+echo "   4. Wiederholen..."
+echo ""
+echo -e "${YELLOW}📊 Infos:${NC}"
+echo "   • Device: $DEVICE_IP"
+echo "   • HTTP-Server: http://$PC_IP:$HTTP_PORT"
+echo "   • Manifest: http://$PC_IP:$HTTP_PORT/manifest.json"
+echo ""
+echo -e "${YELLOW}🧹 Cleanup (zurück zum Normalzustand):${NC}"
+echo "   make localcleanup"
+echo ""

--- a/local_ota_test.sh
+++ b/local_ota_test.sh
@@ -1,0 +1,144 @@
+#!/bin/bash
+
+##############################################################################
+# Local Update - Iterativ neue Firmware bereitstellen
+# 
+# Voraussetzung: Device bereits im Local Dev Mode (make local-release-test)
+# 
+# Workflow:
+# 1. Firmware neu kompilieren
+# 2. manifest.json aktualisieren
+# 3. Fertig! Update im Home Assistant Dashboard verfügbar
+##############################################################################
+
+set -e
+
+# Farben
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+BLUE='\033[0;34m'
+NC='\033[0m'
+
+# Konfiguration
+PROJECT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+STATE_FILE="${PROJECT_DIR}/.local_dev_state"
+HTTP_PORT=8000
+
+echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║          📦 Local Update - Neue Firmware                   ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+
+# ============================================================================
+# Prüfe ob Local Dev Mode aktiv ist
+# ============================================================================
+if [ ! -f "$STATE_FILE" ]; then
+    echo -e "${RED}❌ Local Dev Mode nicht aktiv!${NC}"
+    echo ""
+    echo "   Starte zuerst: make local-release-test"
+    exit 1
+fi
+
+# State laden
+source "$STATE_FILE"
+
+echo -e "${GREEN}✅ Local Dev Mode aktiv${NC}"
+echo "   • Device: $DEVICE_IP"
+echo "   • HTTP-Server: http://$PC_IP:$HTTP_PORT"
+echo ""
+
+# ============================================================================
+# 1. Firmware kompilieren
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 1: Firmware kompilieren...${NC}"
+
+cd "$PROJECT_DIR"
+if ! esphome compile src/main.yaml > /tmp/compile.log 2>&1; then
+    echo -e "${RED}❌ Build fehlgeschlagen${NC}"
+    tail -20 /tmp/compile.log
+    exit 1
+fi
+echo -e "${GREEN}✅ Firmware kompiliert${NC}"
+echo ""
+
+# ============================================================================
+# 2. Firmware-Dateien kopieren & manifest.json aktualisieren
+# ============================================================================
+echo -e "${YELLOW}📍 Schritt 2: Firmware-Dateien aktualisieren...${NC}"
+
+BUILD_DIR="${PROJECT_DIR}/src/.esphome/build/display01"
+PIOENV_DIR="${BUILD_DIR}/.pioenvs/display01"
+mkdir -p "$BUILD_DIR"
+
+# Firmware-Dateien aus dem PlatformIO Build-Verzeichnis kopieren
+# WICHTIG: Die neuste kompilierte Firmware liegt in .pioenvs/display01/
+if [ -f "${PIOENV_DIR}/firmware.ota.bin" ]; then
+    cp "${PIOENV_DIR}/firmware.ota.bin" "${BUILD_DIR}/firmware.ota.bin"
+    echo "   → firmware.ota.bin aktualisiert"
+else
+    echo -e "${RED}❌ firmware.ota.bin nicht gefunden!${NC}"
+    exit 1
+fi
+
+if [ -f "${PIOENV_DIR}/firmware.factory.bin" ]; then
+    cp "${PIOENV_DIR}/firmware.factory.bin" "${BUILD_DIR}/firmware.factory.bin"
+    echo "   → firmware.factory.bin aktualisiert"
+fi
+
+# Checksummen berechnen
+OTA_MD5=$(md5sum "${BUILD_DIR}/firmware.ota.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+OTA_SHA256=$(shasum -a 256 "${BUILD_DIR}/firmware.ota.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+FACTORY_MD5=$(md5sum "${BUILD_DIR}/firmware.factory.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+FACTORY_SHA256=$(shasum -a 256 "${BUILD_DIR}/firmware.factory.bin" 2>/dev/null | cut -d' ' -f1 || echo "unknown")
+
+# Timestamp für Version
+TIMESTAMP=$(date +%H%M%S)
+
+# manifest.json erstellen
+cat > "${BUILD_DIR}/manifest.json" << EOF
+{
+  "name": "tnt_larsn.esphome_display",
+  "version": "LOCAL_DEV_$TIMESTAMP",
+  "home_assistant_domain": "esphome",
+  "new_install_prompt_erase": false,
+  "builds": [
+    {
+      "chipFamily": "ESP32-S3",
+      "ota": {
+        "path": "firmware.ota.bin",
+        "md5": "$OTA_MD5",
+        "sha256": "$OTA_SHA256",
+        "summary": "🧪 Local Dev Build ($TIMESTAMP)",
+        "release_url": "http://$PC_IP:$HTTP_PORT/firmware.ota.bin"
+      },
+      "parts": [
+        {
+          "path": "firmware.factory.bin",
+          "offset": 0,
+          "md5": "$FACTORY_MD5",
+          "sha256": "$FACTORY_SHA256"
+        }
+      ]
+    }
+  ]
+}
+EOF
+
+echo -e "${GREEN}✅ manifest.json aktualisiert (Version: LOCAL_DEV_$TIMESTAMP)${NC}"
+echo ""
+
+# ============================================================================
+# Fertig!
+# ============================================================================
+echo -e "${BLUE}╔════════════════════════════════════════════════════════════╗${NC}"
+echo -e "${BLUE}║         🎉 Update bereit!                                  ║${NC}"
+echo -e "${BLUE}╚════════════════════════════════════════════════════════════╝${NC}"
+echo ""
+echo -e "${GREEN}Nächster Schritt:${NC}"
+echo "   Home Assistant → ESPHome → display01 → 'Firmware aktualisieren'"
+echo ""
+echo -e "${YELLOW}📊 Infos:${NC}"
+echo "   • Version: LOCAL_DEV_$TIMESTAMP"
+echo "   • Manifest: http://$PC_IP:$HTTP_PORT/manifest.json"
+echo ""


### PR DESCRIPTION
## 🚀 Local Dev Mode für ESPHome Display

Dieses Feature ermöglicht schnelle, iterative OTA-Updates **ohne GitHub Releases** während der Entwicklung.

### ✨ Neue Features

#### Makefile-Targets
- **`make localupdate`** - Vollständiger lokaler OTA-Setup mit automatischem HTTP-Server
- **`make localcleanup`** - Aufräumen und Rückkehr zu GitHub-URL

#### Bash-Scripts
- `full_local_release_test.sh` - Initial Setup: Device in Local Dev Mode versetzen
- `local_ota_test.sh` - Iterativ neue Firmware bereitstellen
- `cleanup_ota_test.sh` - Zurück zum Normalzustand

#### Dokumentation
- `MAKEFILE_GUIDE.md` - Umfassende Anleitung für alle neuen Commands

### 🔄 Workflow

```bash
# 1. Initial Setup (einmalig)
make local-release-test

# 2. Iteratives Entwickeln
# Code ändern (z.B. src/pages/home.yaml)
make localupdate
# Home Assistant → ESPHome → display01 → "Update"
# Wiederholen...

# 3. Cleanup (zurück zu GitHub-URL)
make localcleanup
```

### 📦 Geänderte Dateien
- `.gitignore` - Ergänzt um `.http_server.pid`
- `MAKEFILE_GUIDE.md` - Neue Dokumentation
- `cleanup_ota_test.sh` - Cleanup-Script
- `full_local_release_test.sh` - Initial Setup-Script
- `local_ota_test.sh` - Update-Script

### 🎯 Vorteile
- ⚡ Schnelles Iterieren ohne GitHub Release-Prozess
- 🔧 Lokale Tests mit echtem OTA-Update-Mechanismus
- 📝 Automatische manifest.json-Generierung
- 🧹 Einfaches Cleanup zurück zu Production-Setup