### PR TITLE
feat: Display firmware version info in OTA update screen

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -531,7 +531,7 @@ script:
       - lvgl.label.update:
           id: ota_version_info
           text: !lambda |-
-            return id(firmware_update).update_info.current_version + " >> " + id(firmware_update).update_info.latest_version;
+            return std::string(id(firmware_update).update_info.current_version) + " >> " + std::string(id(firmware_update).update_info.latest_version);
       - lvgl.label.update:
           id: ota_percent
           text: "Wird gestartet..."

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -529,6 +529,10 @@ script:
           id: ota_title
           text: "Firmware Download"
       - lvgl.label.update:
+          id: ota_version_info
+          text: !lambda |-
+            return id(firmware_update).update_info.current_version + " >> " + id(firmware_update).update_info.latest_version;
+      - lvgl.label.update:
           id: ota_percent
           text: "Wird gestartet..."
       - lvgl.bar.update:

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -39,7 +39,13 @@ lvgl:
                         y: 0
                         text_font: nunito_20
                         text_color: color_text_dark_primary
-
+                    - label:
+                        id: ota_version_info
+                        text: "von: ${version} nach: ..."
+                        align: top_mid
+                        y: 30
+                        text_font: nunito_16
+                        text_color: color_text_dark_secondary
                     - bar:
                         id: ota_bar
                         width: 100%

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -41,7 +41,7 @@ lvgl:
                         text_color: color_text_dark_primary
                     - label:
                         id: ota_version_info
-                        text: "von: ${version} nach: ..."
+                        text: "${version} >> ..."
                         align: top_mid
                         y: 30
                         text_font: nunito_16


### PR DESCRIPTION
## Beschreibung
Zeigt die aktuelle und neue Firmware-Version beim OTA-Update auf dem Display an.

### Änderungen
- ✨ Neues Label `ota_version_info` in der OTA-Seite hinzugefügt
- 🔄 Versionsformat: `current_version >> latest_version`
- ⚡ Versionen werden dynamisch zur Laufzeit vom `firmware_update` Sensor gelesen
- ♻️ Ersetzt statische `${version}` Substitution mit aktuellen Update-Infos

### Dateien
- `src/pages/ota.yaml`: Neues Label für Versionsinformation
- `src/common/core.yaml`: Lambda zur Anzeige der Versionen

### Technisch
Die Versionsinformation wird dynamisch aus `id(firmware_update).update_info` gelesen:
- `current_version`: Aktuelle laufende Firmware
- `latest_version`: Neue verfügbare Version

Dies ist zuverlässiger als die statische `${version}` Substitution, da sie die tatsächlich installierte Version reflektiert.