### PR TITLE
Add dynamic domain handling for Home Assistant entities

### DIFF
--- a/src/templates/ha_button.yaml
+++ b/src/templates/ha_button.yaml
@@ -35,7 +35,7 @@ button:
           lambda: |-
             std::string domain = id(ha_entity_${num}_domain).state;
             // Domains that support .toggle service
-            const char* toggle_domains[] = {"switch", "light", "fan", "cover", "valve", "input_boolean"};
+            const char* toggle_domains[] = {"switch", "light", "fan", "cover", "valve", "input_boolean", "automation", "script", "remote"};
             for (const char* d : toggle_domains) {
               if (domain == d) return true;
             }

--- a/src/templates/ha_button.yaml
+++ b/src/templates/ha_button.yaml
@@ -77,3 +77,11 @@ button:
                           service: lock.lock
                           data:
                             entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
+    # Unbekannte oder ungültige Domain: Warnung loggen
+    - if:
+        condition:
+          lambda: 'return id(ha_entity_${num}_domain).state == "unknown";'
+        then:
+          - lambda: |-
+              ESP_LOGW("ha_button", "Unknown domain for entity_id '%s' on button ${num}",
+                       id(ha_entity_${num}_id).state.c_str());

--- a/src/templates/ha_button.yaml
+++ b/src/templates/ha_button.yaml
@@ -29,7 +29,47 @@ button:
         align: CENTER
         y: 30
   on_click:
-    - homeassistant.service:
-        service: switch.toggle
-        data:
-          entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
+    # Domains mit nativer .toggle-Unterstützung behandeln
+    - if:
+        condition:
+          lambda: |-
+            std::string domain = id(ha_entity_${num}_domain).state;
+            // Domains that support .toggle service
+            const char* toggle_domains[] = {"switch", "light", "fan", "cover", "valve", "input_boolean"};
+            for (const char* d : toggle_domains) {
+              if (domain == d) return true;
+            }
+            return false;
+        then:
+          - homeassistant.service:
+              service: !lambda |-
+                return std::string(id(ha_entity_${num}_domain).state) + ".toggle";
+              data:
+                entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
+    # Button-Domain nutzt button.press statt toggle
+    - if:
+        condition:
+          lambda: 'return id(ha_entity_${num}_domain).state == "button";'
+        then:
+          - homeassistant.service:
+              service: button.press
+              data:
+                entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
+    # Lock-Domain: lock/unlock abhängig vom aktuellen Zustand
+    - if:
+        condition:
+          lambda: 'return id(ha_entity_${num}_domain).state == "lock";'
+        then:
+          - if:
+              condition:
+                lambda: 'return id(ha_entity_${num}_state_text).state == "locked";'
+              then:
+                - homeassistant.service:
+                    service: lock.unlock
+                    data:
+                      entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
+              else:
+                - homeassistant.service:
+                    service: lock.lock
+                    data:
+                      entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();

--- a/src/templates/ha_button.yaml
+++ b/src/templates/ha_button.yaml
@@ -34,7 +34,7 @@ button:
         condition:
           lambda: |-
             std::string domain = id(ha_entity_${num}_domain).state;
-            // Domains that support .toggle service
+            // Domains die den .toggle Service unterstützen
             const char* toggle_domains[] = {"switch", "light", "fan", "cover", "valve", "input_boolean", "automation", "script", "remote"};
             for (const char* d : toggle_domains) {
               if (domain == d) return true;

--- a/src/templates/ha_button.yaml
+++ b/src/templates/ha_button.yaml
@@ -69,7 +69,11 @@ button:
                     data:
                       entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
               else:
-                - homeassistant.service:
-                    service: lock.lock
-                    data:
-                      entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();
+                - if:
+                    condition:
+                      lambda: 'return id(ha_entity_${num}_state_text).state == "unlocked";'
+                    then:
+                      - homeassistant.service:
+                          service: lock.lock
+                          data:
+                            entity_id: !lambda return id(ha_entity_${num}_id).state.c_str();

--- a/src/templates/ha_entity.yaml
+++ b/src/templates/ha_entity.yaml
@@ -10,6 +10,66 @@ defaults:
   num: "1"
   entity_id: "switch.placeholder"
 
+# Script für verzögerte LVGL Flag-Updates mit Retry-Logik
+# Versucht bis zu 4 mal mit 200ms Pause zwischen Versuchen (max 600ms)
+script:
+  # Helper-Script das die eigentlichen Flag-Updates durchführt
+  - id: apply_button_flags_${num}
+    mode: single
+    then:
+      - lambda: |-
+          auto obj = id(homeassistant_btn_${num});
+          std::string domain = id(ha_entity_${num}_domain).state;
+          
+          if (domain == "button") {
+            lv_obj_clear_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+            lv_obj_clear_state(obj, LV_STATE_CHECKED);
+          } else {
+            lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+          }
+  
+  # Retry-Script mit Timeout-Logik
+  - id: update_button_flags_${num}
+    mode: restart
+    then:
+      # Versuch 1: Sofortige Prüfung
+      - if:
+          condition:
+            lambda: 'return lv_is_initialized();'
+          then:
+            - script.execute: apply_button_flags_${num}
+            - lambda: 'ESP_LOGD("ha_entity", "Button ${num} flags updated immediately");'
+          else:
+            # Versuch 2: Nach 200ms
+            - delay: 200ms
+            - if:
+                condition:
+                  lambda: 'return lv_is_initialized();'
+                then:
+                  - script.execute: apply_button_flags_${num}
+                  - lambda: 'ESP_LOGD("ha_entity", "Button ${num} flags updated after 200ms");'
+                else:
+                  # Versuch 3: Nach weiteren 200ms (400ms total)
+                  - delay: 200ms
+                  - if:
+                      condition:
+                        lambda: 'return lv_is_initialized();'
+                      then:
+                        - script.execute: apply_button_flags_${num}
+                        - lambda: 'ESP_LOGD("ha_entity", "Button ${num} flags updated after 400ms");'
+                      else:
+                        # Versuch 4: Nach weiteren 200ms (600ms total)
+                        - delay: 200ms
+                        - if:
+                            condition:
+                              lambda: 'return lv_is_initialized();'
+                            then:
+                              - script.execute: apply_button_flags_${num}
+                              - lambda: 'ESP_LOGD("ha_entity", "Button ${num} flags updated after 600ms");'
+                            else:
+                              # Timeout nach 600ms
+                              - lambda: 'ESP_LOGW("ha_entity", "Timeout (600ms) waiting for LVGL initialization for button ${num}");'
+
 binary_sensor:
   - platform: homeassistant
     id: ha_entity_state_${num}
@@ -143,11 +203,4 @@ text_sensor:
       return domain;
     on_value:
       then:
-        - lambda: |-
-            auto obj = id(homeassistant_btn_${num});
-            if (x == "button") {
-              lv_obj_clear_flag(obj, LV_OBJ_FLAG_CHECKABLE);
-              lv_obj_clear_state(obj, LV_STATE_CHECKED);
-            } else {
-              lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);
-            }
+        - script.execute: update_button_flags_${num}

--- a/src/templates/ha_entity.yaml
+++ b/src/templates/ha_entity.yaml
@@ -18,10 +18,14 @@ binary_sensor:
     trigger_on_initial_state: true
     on_state:
       then:
-        lvgl.widget.update:
-          id: homeassistant_btn_${num}
-          state:
-            checked: !lambda return x;
+        - if:
+            condition:
+              lambda: 'return id(ha_entity_${num}_domain).state != "button";'
+            then:
+              - lvgl.widget.update:
+                  id: homeassistant_btn_${num}
+                  state:
+                    checked: !lambda return x;
 
 text_sensor:
   # Friendly Name für Button Label
@@ -108,9 +112,42 @@ text_sensor:
                 id: homeassistant_btn_${num}_icon
                 text: !lambda return x.c_str();
 
+  # Entity State als Text Sensor (z.B. für Lock Toggle Logic)
+  - platform: homeassistant
+    id: ha_entity_${num}_state_text
+    entity_id: ${entity_id}
+    internal: true
+
   # Entity ID als Text Sensor (z.B. für Button Service Aufrufe)
   - platform: template
     id: ha_entity_${num}_id
     internal: true
     lambda: |-
       return {"${entity_id}"};
+
+  # Entity Domain als Text Sensor (z.B. für Icon Auswahl)
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: |-
+      std::string entity_id = "${entity_id}";
+      size_t dot_pos = entity_id.find('.');
+      
+      // Validierung: Entity-ID muss einen Punkt enthalten
+      if (dot_pos == std::string::npos) {
+        ESP_LOGW("ha_entity", "Invalid entity_id format '%s': missing dot separator", entity_id.c_str());
+        return std::string("unknown");
+      }
+      
+      std::string domain = entity_id.substr(0, dot_pos);
+      return domain;
+    on_value:
+      then:
+        - lambda: |-
+            auto obj = id(homeassistant_btn_${num});
+            if (x == "button") {
+              lv_obj_clear_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+              lv_obj_clear_state(obj, LV_STATE_CHECKED);
+            } else {
+              lv_obj_add_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+            }


### PR DESCRIPTION
## Zusammenfassung

Implementiert dynamisches Domain-Handling für Home Assistant Entitäten, um verschiedene Entitätstypen korrekt zu behandeln.

## Änderungen

### Button-Template (`ha_button.yaml`)
- ✅ Dynamische Service-Aufrufe basierend auf Entity-Domain
- ✅ Button-Domain nutzt `button.press` statt Toggle
- ✅ Lock-Domain verwendet `lock.lock`/`lock.unlock` basierend auf aktuellem Zustand
- ✅ Toggle-Domains (switch, light, fan, cover, valve, input_boolean) verwenden `.toggle` Service

### Entity-Template (`ha_entity.yaml`)
- ✅ Domain-Extraktion aus Entity-ID mit Validierung
- ✅ Dynamisches Setzen von LVGL-Flags zur Laufzeit
- ✅ Button-Domain erhält `non-checkable` Flag (momentary mode)
- ✅ State-Updates werden nur für nicht-Button-Domains angewendet
- ✅ Text-Sensor für Domain-Verwaltung

## Verhalten

| Domain | Button-Typ | Service | State-Update |
|--------|-----------|---------|--------------|
| `button` | Momentary | `button.press` | ❌ Nein |
| `switch`, `light`, `fan` , `cover`, `valve`, `input_boolean`, `automation`, `script`, `remote`| Toggle | `domain.toggle` | ✅ Ja |
| `lock` | Toggle | `lock.lock` / `lock.unlock` | ✅ Ja |

## Testing


- [x] Kompilierung erfolgreich
- [x] Button-Domain zeigt korrektes momentary-Verhalten
- [x] Toggle-Domains zeigen checked/unchecked States korrekt an
- [x] Service-Aufrufe funktionieren für alle unterstützten Domains

## Dokumentation

Siehe [Copilot Instructions](.github/copilot-instructions.md) für weitere Details zur Template-Architektur.