### PR TITLE
feat: Add DateTime Helper for German date/time formatting

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -28,6 +28,7 @@ esphome:
     - <sstream>
     - <algorithm>
     - helper/mdi_icon_map.h # MDI Icon Helper für dynamische Icon-Konvertierung aus Home Assistant
+    - helper/datetime_helper.h # DateTime Helper für deutsche Datums-/Zeitformatierung
   platformio_options:
     board_build.flash_mode: dio    
   on_boot:
@@ -171,7 +172,16 @@ time:
       - ntp0.ntp-servers.net
       - ntp1.ntp-servers.net
       - ntp2.ntp-servers.net
+    on_time_sync:
+      then:
+        - logger.log: "Zeit synchronisiert - aktualisiere Display"
+        - script.execute: update_datetime_display
     on_time:
+      # Jede Minute Zeit und Datum aktualisieren
+      - seconds: 0
+        then:
+          - script.execute: update_datetime_display
+      # Antiburn zwischen 2:05 und 5:35 Uhr
       - hours: 2,3,4,5
         minutes: 5
         seconds: 0

--- a/src/helper/datetime_helper.h
+++ b/src/helper/datetime_helper.h
@@ -1,0 +1,73 @@
+// DateTime Helper für deutsche Datums- und Zeitformatierung
+// Verwendung in ESPHome Lambdas: DateTimeHelper::get_weekday(), etc.
+
+#pragma once
+#include <string>
+#include <cstdio>
+
+namespace DateTimeHelper {
+
+// Deutsche Wochentage (Sonntag = 1, Samstag = 7)
+inline const char* get_weekday(int day_of_week) {
+    static const char* days[] = {
+        "Sonntag", "Montag", "Dienstag", "Mittwoch",
+        "Donnerstag", "Freitag", "Samstag"
+    };
+    if (day_of_week < 1 || day_of_week > 7) return "---";
+    return days[day_of_week - 1];
+}
+
+// Deutsche Monatsnamen (Januar = 1, Dezember = 12)
+inline const char* get_month(int month) {
+    static const char* months[] = {
+        "Januar", "Februar", "März", "April", "Mai", "Juni",
+        "Juli", "August", "September", "Oktober", "November", "Dezember"
+    };
+    if (month < 1 || month > 12) return "---";
+    return months[month - 1];
+}
+
+// Formatiert Datum als "Montag, 15. März 2026"
+inline std::string format_date_full(int day_of_week, int day, int month, int year) {
+    char buf[64];
+    snprintf(buf, sizeof(buf), "%s, %d. %s %d",
+             get_weekday(day_of_week), day, get_month(month), year);
+    return std::string(buf);
+}
+
+// Formatiert Datum als "15. März 2026" (ohne Wochentag)
+inline std::string format_date_short(int day, int month, int year) {
+    char buf[48];
+    snprintf(buf, sizeof(buf), "%d. %s %d", day, get_month(month), year);
+    return std::string(buf);
+}
+
+// Formatiert Datum als "15.03.2026"
+inline std::string format_date_numeric(int day, int month, int year) {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%02d.%02d.%d", day, month, year);
+    return std::string(buf);
+}
+
+// Formatiert Uhrzeit als "22:45 Uhr"
+inline std::string format_time_24h(int hour, int minute) {
+    char buf[16];
+    snprintf(buf, sizeof(buf), "%02d:%02d Uhr", hour, minute);
+    return std::string(buf);
+}
+
+// Formatiert Uhrzeit als "22:45" (ohne "Uhr")
+inline std::string format_time_simple(int hour, int minute) {
+    char buf[8];
+    snprintf(buf, sizeof(buf), "%02d:%02d", hour, minute);
+    return std::string(buf);
+}
+
+// Formatiert Uhrzeit als "22:45:30"
+inline std::string format_time_with_seconds(int hour, int minute, int second) {
+    char buf[12];
+    snprintf(buf, sizeof(buf), "%02d:%02d:%02d", hour, minute, second);
+    return std::string(buf);
+}
+
+} // namespace DateTimeHelper

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -8,20 +8,91 @@ lvgl:
         - obj: # Container mit GRID Layout für Button-Widgets
             layout:
               type: GRID
-              grid_columns: [FR(1), FR(1), FR(1)]
-              grid_rows: [FR(50), FR(50)]
+              grid_columns: [FR(1)]
+              grid_rows: [FR(30), FR(15), FR(5), FR(25), FR(25)]
             width: 100%
-            height: 61.8%
-            pad_all: 15
+            height: 100%
+            pad_all: 10
             pad_top: 22
             bg_opa: TRANSP
             border_opa: TRANSP
             widgets:
-              # Buttons via Template-Include (col 0-2, row 0-1)
-              # default_icon ist optional, Standard ist "mdi:lightbulb"
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "1", col: "0", row: "0" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "2", col: "0", row: "1" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "3", col: "1", row: "0" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "4", col: "1", row: "1" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "5", col: "2", row: "0" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "6", col: "2", row: "1" } }
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 0
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: CENTER
+                    align: CENTER
+                    id: homeassistant_btn_7_icon
+                    text: ha_entity_7_icon
+                    text_color: color_text_light_primary
+                    bg_opa: TRANSP
+                    text_font: weather_icons
+                
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 1
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: START
+                    align: CENTER
+                    id: homeassistant_btn_7_label
+                    text: "Wetter bei -- °C"
+                    text_font: roboto24
+                    text_color: color_text_light_primary
+
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 3
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: END
+                    align: CENTER
+                    id: display_time
+                    text: !lambda |-
+                      auto now = id(sntp_time).now();
+                      if (!now.is_valid()) return std::string("--:--");
+                      return DateTimeHelper::format_time_simple(now.hour, now.minute);
+                    text_font: roboto90
+                    text_color: color_text_light_primary
+                    
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 2
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: START
+                    align: CENTER
+                    id: display_date
+                    text: !lambda |-
+                      auto now = id(sntp_time).now();
+                      if (!now.is_valid()) return std::string("---");
+                      return DateTimeHelper::format_date_short(now.day_of_month, now.month, now.year);
+                    text_font: roboto24
+                    text_color: color_text_light_primary
+                    
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 4
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: CENTER
+                    align: CENTER
+                    id: display_house_temp
+                    text: house temp
+                    text_font: roboto24
+                    text_color: color_text_light_primary
+
+script: 
+    # Aktualisierung von Zeit- und Datums-Display
+    - id: update_datetime_display
+      mode: single
+      then:
+        - lvgl.label.update:
+            id: display_time
+            text: !lambda |-
+                auto now = id(sntp_time).now();
+                if (!now.is_valid()) return std::string("--:--");
+                return DateTimeHelper::format_time_simple(now.hour, now.minute);
+        - lvgl.label.update:
+            id: display_date
+            text: !lambda |-
+                auto now = id(sntp_time).now();
+                if (!now.is_valid()) return std::string("---");
+                return DateTimeHelper::format_date_short(now.day_of_month, now.month, now.year);


### PR DESCRIPTION
## Zusammenfassung

Diese PR fügt einen DateTime Helper für deutsche Datums- und Zeitformatierung hinzu.

## Änderungen

- **Neuer Helper**: `datetime_helper.h` mit deutschen Wochentags- und Monatsnamen
- **Home Page**: Zeit- und Datumsanzeige mit `DateTimeHelper`
- **Time Sync**: Automatische Aktualisierung bei Zeitsynchronisation und jede Minute
- **Core YAML**: Include für `datetime_helper.h` hinzugefügt

## Neue Funktionen

- `DateTimeHelper::get_weekday()` - Deutsche Wochentage
- `DateTimeHelper::get_month()` - Deutsche Monatsnamen
- `DateTimeHelper::format_date_full()` - "Montag, 15. März 2026"
- `DateTimeHelper::format_date_short()` - "15. März 2026"
- `DateTimeHelper::format_time_simple()` - "22:45"