### PR TITLE
feat: Add navigation bar and multi-page support

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -391,6 +391,7 @@ ota:
             then:
               - lvgl.resume:
               - lvgl.widget.redraw:
+        - lvgl.widget.hide: navigation_bar
         - lvgl.page.show: ota_page
         - lvgl.label.update:
             id: ota_title
@@ -440,6 +441,7 @@ ota:
             then:
               - lvgl.resume:
               - lvgl.widget.redraw:
+        - lvgl.widget.hide: navigation_bar
         - lvgl.page.show: ota_page
         - lvgl.label.update:
             id: ota_title
@@ -524,6 +526,7 @@ script:
           then:
             - lvgl.resume:
             - lvgl.widget.redraw:
+      - lvgl.widget.hide: navigation_bar
       - lvgl.page.show: ota_page
       - lvgl.label.update:
           id: ota_title

--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -478,6 +478,16 @@
         "\U000F02D7", # weather-cloudy (fallback/additional)
       ]
 
+- file: "gfonts://Roboto"
+  id: roboto40
+  size: 40
+  bpp: 4
+  
+- file: "gfonts://Roboto"
+  id: roboto90
+  size: 90
+  bpp: 4
+
 - file: "assets/fonts/materialdesignicons-webfont.ttf"
   id: btn_icons_font
   size: 64

--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -478,16 +478,6 @@
         "\U000F02D7", # weather-cloudy (fallback/additional)
       ]
 
-- file: "gfonts://Roboto"
-  id: roboto40
-  size: 40
-  bpp: 4
-  
-- file: "gfonts://Roboto"
-  id: roboto90
-  size: 90
-  bpp: 4
-
 - file: "assets/fonts/materialdesignicons-webfont.ttf"
   id: btn_icons_font
   size: 64

--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -380,6 +380,10 @@
     "\U000F12D4", # garage_opened
     "\U000F00AC", # blinds_closed 
     "\U000F1011", # blinds_opened
+    "\U000F0140", # chevron-down
+    "\U000F0141", # chevron-left
+    "\U000F0142", # chevron-right
+    "\U000F0143", # chevron-up
   ]
 
 - file: "assets/fonts/materialdesignicons-webfont.ttf"
@@ -422,6 +426,7 @@
         "\U000F0748",
         "\U000F1A1B",
         "\U000F02DC",
+        "\U000F02D7", # additional weather icon fallback
         "\U000F0A02",
         "\U000F035F",
         "\U000F0156",
@@ -434,7 +439,7 @@
 
 - file: "gfonts://Roboto"
   id: weather_icons
-  size: 110
+  size: 120
   bpp: 4
   extras:
     - file: 'assets/fonts/materialdesignicons-webfont.ttf' # http://materialdesignicons.com/cdn/7.4.47/ 
@@ -470,7 +475,18 @@
         "\U000F059D", # windy
         "\U000F059E", # windyvariant
         "\U000F01F5", # happyface
+        "\U000F02D7", # weather-cloudy (fallback/additional)
       ]
+
+- file: "gfonts://Roboto"
+  id: roboto40
+  size: 40
+  bpp: 4
+  
+- file: "gfonts://Roboto"
+  id: roboto90
+  size: 90
+  bpp: 4
 
 - file: "assets/fonts/materialdesignicons-webfont.ttf"
   id: btn_icons_font

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -11,17 +11,18 @@ packages:
     file: ../templates/ha_entity.yaml
     vars:
       num: "1"
-      entity_id: switch.shellypro3_ece334e98834_output_0
-  ha_entity_2: !include
-    file: ../templates/ha_entity.yaml
+      entity_id: light.burolampe
+  # Button verwendet spezielles Template (kein binary_sensor, da State ein Timestamp ist)
+  ha_button_2: !include
+    file: ../templates/ha_button_entity.yaml
     vars:
       num: "2"
-      entity_id: switch.shellypro3_ece334e98834_output_1
+      entity_id: button.light_panels_50_3d_5b_identifizieren
   ha_entity_3: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "3"
-      entity_id: switch.shellypro3_ece334e98834_output_2
+      entity_id: switch.display_buero_switch_40
   ha_entity_4: !include
     file: ../templates/ha_entity.yaml
     vars:
@@ -37,3 +38,9 @@ packages:
     vars:
       num: "6"
       entity_id: switch.shellypro3_ece334ed6054_output_2
+  # Wetter verwendet spezielles Template (text_sensor statt binary_sensor)
+  ha_weather_7: !include
+    file: ../templates/ha_weather.yaml
+    vars:
+      num: "7"
+      entity_id: weather.home

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -11,18 +11,17 @@ packages:
     file: ../templates/ha_entity.yaml
     vars:
       num: "1"
-      entity_id: light.burolampe
-  # Button verwendet spezielles Template (kein binary_sensor, da State ein Timestamp ist)
-  ha_button_2: !include
-    file: ../templates/ha_button_entity.yaml
+      entity_id: switch.shellypro3_ece334e98834_output_0
+  ha_entity_2: !include
+    file: ../templates/ha_entity.yaml
     vars:
       num: "2"
-      entity_id: button.light_panels_50_3d_5b_identifizieren
+      entity_id: switch.shellypro3_ece334e98834_output_1
   ha_entity_3: !include
     file: ../templates/ha_entity.yaml
     vars:
       num: "3"
-      entity_id: switch.display_buero_switch_40
+      entity_id: switch.shellypro3_ece334e98834_output_2
   ha_entity_4: !include
     file: ../templates/ha_entity.yaml
     vars:
@@ -43,4 +42,4 @@ packages:
     file: ../templates/ha_weather.yaml
     vars:
       num: "7"
-      entity_id: weather.home
+      entity_id: weather.wetter_garten

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -4,7 +4,9 @@ packages:
   homeassistant: !include common/homeassistant.yaml
   boot_screen: !include pages/boot.yaml
   home_page: !include pages/home.yaml
+  switches_page: !include pages/switches.yaml
   ota_page: !include pages/ota.yaml
+  navigation: !include pages/navigation.yaml
   theme: !include themes/homeassistant.yaml
 
 substitutions: !include common/substitutions.yaml

--- a/src/pages/boot.yaml
+++ b/src/pages/boot.yaml
@@ -103,6 +103,7 @@ script:
 
   - id: update_loading_page
     then:
+      - lvgl.widget.hide: navigation_bar
       - lvgl.label.update:
           id: boot_synchronization_label
           text: "Synchronisiere..."
@@ -143,8 +144,10 @@ script:
 
       - delay: 1s
       - lvgl.widget.hide: loading_page
+      - lambda: 'id(current_page_index) = 0;'
       - lvgl.page.show:
           id: home_page
+      - lvgl.widget.show: navigation_bar
 
 
   - id: on_ha_connected

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -8,20 +8,91 @@ lvgl:
         - obj: # Container mit GRID Layout für Button-Widgets
             layout:
               type: GRID
-              grid_columns: [FR(1), FR(1), FR(1)]
-              grid_rows: [FR(50), FR(50)]
+              grid_columns: [FR(1)]
+              grid_rows: [FR(30), FR(15), FR(5), FR(25), FR(25)]
             width: 100%
-            height: 61.8%
-            pad_all: 15
+            height: 100%
+            pad_all: 10
             pad_top: 22
             bg_opa: TRANSP
             border_opa: TRANSP
             widgets:
-              # Buttons via Template-Include (col 0-2, row 0-1)
-              # default_icon ist optional, Standard ist "mdi:lightbulb"
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "1", col: "0", row: "0" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "2", col: "0", row: "1" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "3", col: "1", row: "0" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "4", col: "1", row: "1" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "5", col: "2", row: "0" } }
-              - !include { file: ../templates/ha_button.yaml, vars: { num: "6", col: "2", row: "1" } }
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 0
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: CENTER
+                    align: CENTER
+                    id: homeassistant_btn_7_icon
+                    text: ha_entity_7_icon
+                    text_color: color_text_light_primary
+                    bg_opa: TRANSP
+                    text_font: weather_icons
+                
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 1
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: START
+                    align: CENTER
+                    id: homeassistant_btn_7_label
+                    text: "Wetter bei -- °C"
+                    text_font: roboto24
+                    text_color: color_text_light_primary
+
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 3
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: END
+                    align: CENTER
+                    id: display_time
+                    text: !lambda |-
+                      auto now = id(sntp_time).now();
+                      if (!now.is_valid()) return std::string("--:--");
+                      return DateTimeHelper::format_time_simple(now.hour, now.minute);
+                    text_font: roboto90
+                    text_color: color_text_light_primary
+                    
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 2
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: START
+                    align: CENTER
+                    id: display_date
+                    text: !lambda |-
+                      auto now = id(sntp_time).now();
+                      if (!now.is_valid()) return std::string("---");
+                      return DateTimeHelper::format_date_short(now.day_of_month, now.month, now.year);
+                    text_font: roboto24
+                    text_color: color_text_light_primary
+                    
+                - label:
+                    grid_cell_column_pos: 0
+                    grid_cell_row_pos: 4
+                    grid_cell_x_align: CENTER
+                    grid_cell_y_align: CENTER
+                    align: CENTER
+                    id: display_house_temp
+                    text: house temp
+                    text_font: roboto24
+                    text_color: color_text_light_primary
+
+script: 
+    # Aktualisierung von Zeit- und Datums-Display
+    - id: update_datetime_display
+      mode: single
+      then:
+        - lvgl.label.update:
+            id: display_time
+            text: !lambda |-
+                auto now = id(sntp_time).now();
+                if (!now.is_valid()) return std::string("--:--");
+                return DateTimeHelper::format_time_simple(now.hour, now.minute);
+        - lvgl.label.update:
+            id: display_date
+            text: !lambda |-
+                auto now = id(sntp_time).now();
+                if (!now.is_valid()) return std::string("---");
+                return DateTimeHelper::format_date_short(now.day_of_month, now.month, now.year);

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -22,7 +22,6 @@ lvgl:
                     grid_cell_row_pos: 0
                     grid_cell_x_align: CENTER
                     grid_cell_y_align: CENTER
-                    align: CENTER
                     id: homeassistant_btn_7_icon
                     text: ha_entity_7_icon
                     text_color: color_text_light_primary
@@ -34,7 +33,6 @@ lvgl:
                     grid_cell_row_pos: 1
                     grid_cell_x_align: CENTER
                     grid_cell_y_align: START
-                    align: CENTER
                     id: homeassistant_btn_7_label
                     text: "Wetter bei -- °C"
                     text_font: roboto24
@@ -45,7 +43,6 @@ lvgl:
                     grid_cell_row_pos: 3
                     grid_cell_x_align: CENTER
                     grid_cell_y_align: END
-                    align: CENTER
                     id: display_time
                     text: !lambda |-
                       auto now = id(sntp_time).now();
@@ -59,7 +56,6 @@ lvgl:
                     grid_cell_row_pos: 2
                     grid_cell_x_align: CENTER
                     grid_cell_y_align: START
-                    align: CENTER
                     id: display_date
                     text: !lambda |-
                       auto now = id(sntp_time).now();
@@ -73,7 +69,6 @@ lvgl:
                     grid_cell_row_pos: 4
                     grid_cell_x_align: CENTER
                     grid_cell_y_align: CENTER
-                    align: CENTER
                     id: display_house_temp
                     text: house temp
                     text_font: roboto24

--- a/src/pages/navigation.yaml
+++ b/src/pages/navigation.yaml
@@ -110,7 +110,7 @@ script:
       - script.execute: show_current_page
 
   # Aktuelle Seite basierend auf Index anzeigen
-  # ESPHome 2026.1.x: Verwende lvgl.page.show statt lv_disp_load_scr()
+  # Ab ESPHome 2026.1.x: Navigation erfolgt über lvgl.page.show (anstatt lv_disp_load_scr())
   - id: show_current_page
     then:
       - if:

--- a/src/pages/navigation.yaml
+++ b/src/pages/navigation.yaml
@@ -1,0 +1,151 @@
+# Globale Navigation für alle Pages
+# Wird als top_layer über allen Seiten angezeigt (außer Boot/OTA)
+
+# Page-Index für Navigation
+# 0 = home_page
+# 1 = switches_page
+# Weitere Pages hier hinzufügen und TOTAL_PAGES anpassen
+
+globals:
+  - id: current_page_index
+    type: int
+    restore_value: no
+    initial_value: '0'
+
+  - id: total_pages
+    type: int
+    restore_value: no
+    initial_value: '2'
+
+lvgl:
+  top_layer:
+    widgets:
+      # Navigation Bar am unteren Rand
+      - obj:
+          id: navigation_bar
+          align: BOTTOM_MID
+          width: 100%
+          height: 60
+          pad_all: 2
+          bg_color: color_bg_light_secondary
+          bg_opa: 80%
+          radius: 0
+          border_opa: TRANSP
+          shadow_opa: TRANSP
+          hidden: true
+          layout:
+            type: GRID
+            grid_columns: [FR(1), FR(1)]
+            grid_rows: [FR(1)]
+          widgets:
+            # Zurück-Button (links)
+            - button:
+                id: nav_btn_prev
+                grid_cell_column_pos: 0
+                grid_cell_row_pos: 0
+                grid_cell_x_align: STRETCH
+                grid_cell_y_align: STRETCH
+                radius: 10
+                shadow_opa: TRANSP
+                on_click:
+                  then:
+                    - script.execute: navigate_prev
+                widgets:
+                  - label:
+                      id: nav_btn_prev_icon
+                      align: CENTER
+                      text_font: mdi_icons_40
+                      text_color: color_text_light_primary
+
+            # Vor-Button (rechts)
+            - button:
+                id: nav_btn_next
+                grid_cell_column_pos: 1
+                grid_cell_row_pos: 0
+                grid_cell_x_align: STRETCH
+                grid_cell_y_align: STRETCH
+                radius: 10
+                shadow_opa: TRANSP
+                on_click:
+                  then:
+                    - script.execute: navigate_next
+                widgets:
+                  - label:
+                      id: nav_btn_next_icon
+                      align: CENTER
+                      text_font: mdi_icons_40
+                      text_color: color_text_light_primary
+
+# Icons via MdiIconHelper setzen (on_boot)
+esphome:
+  on_boot:
+    priority: -50
+    then:
+      - lambda: |-
+          static MdiIconHelper helper;
+          lv_label_set_text(id(nav_btn_prev_icon), helper.convert_mdi_icon("mdi:chevron-left").c_str());
+          lv_label_set_text(id(nav_btn_next_icon), helper.convert_mdi_icon("mdi:chevron-right").c_str());
+
+script:
+  # Navigation zur vorherigen Seite
+  - id: navigate_prev
+    then:
+      - lambda: |-
+          int current = id(current_page_index);
+          int total = id(total_pages);
+          // Wrap-around: von 0 zurück zu letzter Seite
+          current = (current - 1 + total) % total;
+          id(current_page_index) = current;
+      - script.execute: show_current_page
+
+  # Navigation zur nächsten Seite
+  - id: navigate_next
+    then:
+      - lambda: |-
+          int current = id(current_page_index);
+          int total = id(total_pages);
+          // Wrap-around: von letzter Seite weiter zu 0
+          current = (current + 1) % total;
+          id(current_page_index) = current;
+      - script.execute: show_current_page
+
+  # Aktuelle Seite basierend auf Index anzeigen
+  # ESPHome 2026.1.x: Verwende lvgl.page.show statt lv_disp_load_scr()
+  - id: show_current_page
+    then:
+      - if:
+          condition:
+            lambda: 'return id(current_page_index) == 0;'
+          then:
+            - lvgl.page.show: home_page
+          else:
+            - if:
+                condition:
+                  lambda: 'return id(current_page_index) == 1;'
+                then:
+                  - lvgl.page.show: switches_page
+                else:
+                  # Fallback: Zurück zur Home-Seite
+                  - lambda: 'id(current_page_index) = 0;'
+                  - lvgl.page.show: home_page
+
+  # Navigation Bar ein-/ausblenden
+  - id: show_navigation
+    then:
+      - lvgl.widget.show: navigation_bar
+
+  - id: hide_navigation
+    then:
+      - lvgl.widget.hide: navigation_bar
+
+  # Zu bestimmter Seite navigieren (per Index)
+  - id: navigate_to_page
+    parameters:
+      page_index: int
+    then:
+      - lambda: |-
+          int total = id(total_pages);
+          if (page_index >= 0 && page_index < total) {
+            id(current_page_index) = page_index;
+          }
+      - script.execute: show_current_page

--- a/src/pages/ota.yaml
+++ b/src/pages/ota.yaml
@@ -7,59 +7,74 @@ lvgl:
       widgets:
         - obj:
             bg_color: color_surface_dark
-            shadow_opa: transp
-            width: ${display_width}
-            height: ${display_height}
-            outline_width: 0
-            border_width: 0
+            shadow_opa: TRANSP
+            border_opa: TRANSP
+            width: 100%
+            height: 100%
+            pad_all: 20
             radius: 0
+            layout:
+              type: GRID
+              grid_columns: [FR(1)]
+              grid_rows: [FR(30), FR(15), FR(20), FR(8), FR(17), FR(10)]
             widgets:
+              # Row 0: Home Assistant Logo
               - image:
-                  y: 30
-                  align: top_mid
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 0
+                  grid_cell_x_align: CENTER
+                  grid_cell_y_align: END
                   src: ha_img
 
+              # Row 1: Spacer
               - obj:
-                  id: ota_container
-                  y: 180
-                  width: 300
-                  height: 200
-                  pad_all: 0
-                  align: top_mid
-                  bg_opa: transp
-                  shadow_opa: transp
-                  border_opa: transp
-                  border_width: 0
-                  radius: 10
-                  widgets:
-                    - label:
-                        id: ota_title
-                        text: "Firmware Update"
-                        align: top_mid
-                        y: 0
-                        text_font: nunito_20
-                        text_color: color_text_dark_primary
-                    - label:
-                        id: ota_version_info
-                        text: "${version} >> ..."
-                        align: top_mid
-                        y: 30
-                        text_font: nunito_16
-                        text_color: color_text_dark_secondary
-                    - bar:
-                        id: ota_bar
-                        width: 100%
-                        height: 30
-                        align: center
-                        y: 20
-                        min_value: 0
-                        max_value: 100
-                        value: 0
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 1
+                  bg_opa: TRANSP
+                  border_opa: TRANSP
 
-                    - label:
-                        id: ota_percent
-                        text: "0 %"
-                        align: center
-                        y: 60
-                        text_font: nunito_20
-                        text_color: color_text_dark_primary
+              # Row 2: OTA Titel
+              - label:
+                  id: ota_title
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 2
+                  grid_cell_x_align: CENTER
+                  grid_cell_y_align: CENTER
+                  text: "Firmware Update"
+                  text_font: nunito_20
+                  text_color: color_text_dark_primary
+
+              # Row 3: Version Info
+              - label:
+                  id: ota_version_info
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 3
+                  grid_cell_x_align: CENTER
+                  grid_cell_y_align: START
+                  text: "${version} >> ..."
+                  text_font: nunito_16
+                  text_color: color_text_dark_secondary
+
+              # Row 4: Progress Bar
+              - bar:
+                  id: ota_bar
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 4
+                  grid_cell_x_align: CENTER
+                  grid_cell_y_align: CENTER
+                  width: 300
+                  height: 30
+                  min_value: 0
+                  max_value: 100
+                  value: 0
+
+              # Row 5: Prozent-Anzeige
+              - label:
+                  id: ota_percent
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 5
+                  grid_cell_x_align: CENTER
+                  grid_cell_y_align: START
+                  text: "0 %"
+                  text_font: nunito_20
+                  text_color: color_text_dark_primary

--- a/src/pages/switches.yaml
+++ b/src/pages/switches.yaml
@@ -1,0 +1,27 @@
+lvgl:
+  pages:
+    - id: switches_page
+      widgets:
+        - image:
+            align: CENTER
+            src: see_img
+        - obj: # Container mit GRID Layout für Button-Widgets
+            layout:
+              type: GRID
+              grid_columns: [FR(1), FR(1), FR(1)]
+              grid_rows: [FR(50), FR(50)]
+            width: 100%
+            height: 61.8%
+            pad_all: 15
+            pad_top: 22
+            bg_opa: TRANSP
+            border_opa: TRANSP
+            widgets:
+              # Buttons via Template-Include (col 0-2, row 0-1)
+              # default_icon ist optional, Standard ist "mdi:lightbulb"
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "1", col: "0", row: "0" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "2", col: "0", row: "1" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "3", col: "1", row: "0" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "4", col: "1", row: "1" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "5", col: "2", row: "0" } }
+              - !include { file: ../templates/ha_button.yaml, vars: { num: "6", col: "2", row: "1" } }

--- a/src/templates/ha_button_entity.yaml
+++ b/src/templates/ha_button_entity.yaml
@@ -1,0 +1,108 @@
+# Template für Home Assistant Button Entity
+# Spezielles Template für Button-Entitäten, da diese keinen binären State haben
+# sondern einen Timestamp (wann zuletzt gedrückt).
+#
+# Variablen: num, entity_id
+# Liefert: Friendly Name, Icon, Entity ID (KEIN binary_sensor!)
+
+defaults:
+  num: "2"
+  entity_id: "button.placeholder"
+
+# Script für verzögerte LVGL Flag-Updates mit Retry-Logik
+script:
+  - id: apply_button_flags_${num}
+    mode: single
+    then:
+      - lambda: |-
+          auto obj = id(homeassistant_btn_${num});
+          // Buttons sind nicht checkable
+          lv_obj_clear_flag(obj, LV_OBJ_FLAG_CHECKABLE);
+          lv_obj_clear_state(obj, LV_STATE_CHECKED);
+  
+  - id: update_button_flags_${num}
+    mode: restart
+    then:
+      - if:
+          condition:
+            lambda: 'return lv_is_initialized();'
+          then:
+            - script.execute: apply_button_flags_${num}
+          else:
+            - delay: 200ms
+            - if:
+                condition:
+                  lambda: 'return lv_is_initialized();'
+                then:
+                  - script.execute: apply_button_flags_${num}
+                else:
+                  - delay: 200ms
+                  - script.execute: apply_button_flags_${num}
+
+text_sensor:
+  # Friendly Name für Button Label
+  - platform: homeassistant
+    id: ha_entity_${num}_friendly_name
+    entity_id: ${entity_id}
+    attribute: friendly_name
+    internal: true
+    on_value:
+      then:
+        lvgl.label.update:
+          id: homeassistant_btn_${num}_label
+          text: !lambda return x.c_str();
+
+  # Icon für Button
+  - platform: homeassistant
+    id: ha_entity_${num}_icon
+    entity_id: ${entity_id}
+    attribute: icon
+    internal: true
+    on_value:
+      then:
+        lvgl.label.update:
+          id: homeassistant_btn_${num}_icon
+          text: !lambda |-
+            static MdiIconHelper helper;
+            if (!x.empty()) {
+              return helper.convert_mdi_icon(x);
+            }
+            return id(ha_entity_${num}_default_icon).state;
+
+  # Default Icon (Button-Pointer)
+  - platform: template
+    id: ha_entity_${num}_default_icon
+    internal: true
+    lambda: |-
+      static MdiIconHelper helper;
+      return helper.convert_mdi_icon("mdi:button-pointer");
+    on_value:
+      then:
+        - if:
+            condition:
+              lambda: 'return id(ha_entity_${num}_icon).state.empty();'
+            then:
+              lvgl.label.update:
+                id: homeassistant_btn_${num}_icon
+                text: !lambda return x.c_str();
+
+  # Entity ID als Text Sensor
+  - platform: template
+    id: ha_entity_${num}_id
+    internal: true
+    lambda: 'return {"${entity_id}"};'
+
+  # Entity State als Text (für Kompatibilität mit ha_button.yaml)
+  - platform: homeassistant
+    id: ha_entity_${num}_state_text
+    entity_id: ${entity_id}
+    internal: true
+
+  # Entity Domain (immer "button")
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: 'return {"button"};'
+    on_value:
+      then:
+        - script.execute: update_button_flags_${num}

--- a/src/templates/ha_entity.yaml
+++ b/src/templates/ha_entity.yaml
@@ -70,6 +70,9 @@ script:
                               # Timeout nach 600ms
                               - lambda: 'ESP_LOGW("ha_entity", "Timeout (600ms) waiting for LVGL initialization for button ${num}");'
 
+# Binary Sensor für Entity State (nur für toggle-fähige Domains)
+# Hinweis: Domains wie "button" oder "weather" haben keinen binären State
+# und erzeugen eine Warnung - diese ist harmlos da die Logik den State ignoriert
 binary_sensor:
   - platform: homeassistant
     id: ha_entity_state_${num}
@@ -80,7 +83,10 @@ binary_sensor:
       then:
         - if:
             condition:
-              lambda: 'return id(ha_entity_${num}_domain).state != "button";'
+              # Nur für toggle-fähige Domains den checked-State aktualisieren
+              lambda: |-
+                std::string domain = id(ha_entity_${num}_domain).state;
+                return domain != "button" && domain != "weather" && domain != "sensor" && domain != "scene" && domain != "script";
             then:
               - lvgl.widget.update:
                   id: homeassistant_btn_${num}
@@ -158,6 +164,7 @@ text_sensor:
       if (domain == "device_tracker") return helper.convert_mdi_icon("mdi:account");
       if (domain == "water_heater") return helper.convert_mdi_icon("mdi:water-boiler");
       if (domain == "update") return helper.convert_mdi_icon("mdi:package");
+      if (domain == "weather") return helper.convert_mdi_icon("mdi:weather-cloudy");
       
       // Fallback für unbekannte Domains
       return helper.convert_mdi_icon("mdi:help-circle");

--- a/src/templates/ha_weather.yaml
+++ b/src/templates/ha_weather.yaml
@@ -119,7 +119,9 @@ sensor:
             } else {
               snprintf(buf, sizeof(buf), "%s bei %.1f °C", weather_text.c_str(), x);
             }
-            lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
+            if (lv_is_initialized()) {
+              lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
+            }
 
   # Luftfeuchtigkeit
   - platform: homeassistant

--- a/src/templates/ha_weather.yaml
+++ b/src/templates/ha_weather.yaml
@@ -51,7 +51,9 @@ text_sensor:
             else icon = "mdi:weather-cloudy"; // Fallback
             
             auto icon_text = helper.convert_mdi_icon(icon);
-            lv_label_set_text(id(homeassistant_btn_${num}_icon), icon_text.c_str());
+            if (lv_is_initialized()) {
+              lv_label_set_text(id(homeassistant_btn_${num}_icon), icon_text.c_str());
+            }   
             
             ESP_LOGD("ha_weather", "Weather state: %s -> Icon: %s", x.c_str(), icon.c_str());
         - lambda: |-
@@ -83,7 +85,9 @@ text_sensor:
             } else {
               snprintf(buf, sizeof(buf), "%s bei %.1f °C", translated.c_str(), id(weather_${num}_temp_value));
             }
-            lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
+            if (lv_is_initialized()) {
+              lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
+            }
 
   # Friendly Name (für alternatives Label falls gewünscht)
   - platform: homeassistant

--- a/src/templates/ha_weather.yaml
+++ b/src/templates/ha_weather.yaml
@@ -1,0 +1,136 @@
+# Template für Home Assistant Weather Entity
+# Spezielles Template für Wetter-Entitäten, da diese keinen binären State haben
+# sondern Text-Zustände wie "partlycloudy", "sunny", "rainy", etc.
+#
+# Variablen: num, entity_id
+# Liefert: Icon (dynamisch nach Wetterzustand), Friendly Name, Temperatur, etc.
+
+defaults:
+  num: "7"
+  entity_id: "weather.home"
+
+globals:
+  - id: weather_${num}_state_text
+    type: std::string
+    restore_value: no
+    initial_value: '"--"'
+  - id: weather_${num}_temp_value
+    type: float
+    restore_value: no
+    initial_value: 'NAN'
+
+text_sensor:
+  # Wetterzustand (z.B. "partlycloudy", "sunny", "rainy")
+  - platform: homeassistant
+    id: ha_weather_${num}_state
+    entity_id: ${entity_id}
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            // Wetterzustand-zu-Icon Mapping (Home Assistant Standard)
+            // https://www.home-assistant.io/integrations/weather/
+            static MdiIconHelper helper;
+            std::string icon;
+            
+            if (x == "clear-night") icon = "mdi:weather-night";
+            else if (x == "cloudy") icon = "mdi:weather-cloudy";
+            else if (x == "fog") icon = "mdi:weather-fog";
+            else if (x == "hail") icon = "mdi:weather-rainy";
+            else if (x == "lightning") icon = "mdi:weather-lightning";
+            else if (x == "lightning-rainy") icon = "mdi:weather-lightning";
+            else if (x == "partlycloudy") icon = "mdi:weather-partly-cloudy";
+            else if (x == "pouring") icon = "mdi:weather-rainy";
+            else if (x == "rainy") icon = "mdi:weather-rainy";
+            else if (x == "snowy") icon = "mdi:weather-snowy";
+            else if (x == "snowy-rainy") icon = "mdi:weather-snowy";
+            else if (x == "sunny") icon = "mdi:weather-sunny";
+            else if (x == "windy") icon = "mdi:weather-windy";
+            else if (x == "windy-variant") icon = "mdi:weather-windy";
+            else if (x == "exceptional") icon = "mdi:alert-circle";
+            else icon = "mdi:weather-cloudy"; // Fallback
+            
+            auto icon_text = helper.convert_mdi_icon(icon);
+            lv_label_set_text(id(homeassistant_btn_${num}_icon), icon_text.c_str());
+            
+            ESP_LOGD("ha_weather", "Weather state: %s -> Icon: %s", x.c_str(), icon.c_str());
+        - lambda: |-
+            // Deutsche Übersetzung speichern
+            std::string state = id(ha_weather_${num}_state).state;
+            std::string translated;
+            if (state == "clear-night") translated = "Klare Nacht";
+            else if (state == "cloudy") translated = "Bewölkt";
+            else if (state == "fog") translated = "Nebel";
+            else if (state == "hail") translated = "Hagel";
+            else if (state == "lightning") translated = "Gewitter";
+            else if (state == "lightning-rainy") translated = "Gewitter";
+            else if (state == "partlycloudy") translated = "Teils bewölkt";
+            else if (state == "pouring") translated = "Starkregen";
+            else if (state == "rainy") translated = "Regnerisch";
+            else if (state == "snowy") translated = "Schnee";
+            else if (state == "snowy-rainy") translated = "Schneeregen";
+            else if (state == "sunny") translated = "Sonnig";
+            else if (state == "windy") translated = "Windig";
+            else if (state == "windy-variant") translated = "Windig";
+            else if (state == "exceptional") translated = "Außergewöhnlich";
+            else translated = state;
+            id(weather_${num}_state_text) = translated;
+            
+            // Kombiniertes Label aktualisieren
+            char buf[64];
+            if (std::isnan(id(weather_${num}_temp_value))) {
+              snprintf(buf, sizeof(buf), "%s bei -- °C", translated.c_str());
+            } else {
+              snprintf(buf, sizeof(buf), "%s bei %.1f °C", translated.c_str(), id(weather_${num}_temp_value));
+            }
+            lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
+
+  # Friendly Name (für alternatives Label falls gewünscht)
+  - platform: homeassistant
+    id: ha_weather_${num}_friendly_name
+    entity_id: ${entity_id}
+    attribute: friendly_name
+    internal: true
+
+  # Domain für Kompatibilität mit anderen Templates
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: 'return {"weather"};'
+
+sensor:
+  # Temperatur
+  - platform: homeassistant
+    id: ha_weather_${num}_temperature
+    entity_id: ${entity_id}
+    attribute: temperature
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            // Temperatur speichern
+            id(weather_${num}_temp_value) = x;
+            
+            // Kombiniertes Label aktualisieren
+            char buf[64];
+            std::string weather_text = id(weather_${num}_state_text);
+            if (weather_text.empty() || weather_text == "--") {
+              snprintf(buf, sizeof(buf), "--, %.1f °C", x);
+            } else {
+              snprintf(buf, sizeof(buf), "%s, %.1f °C", weather_text.c_str(), x);
+            }
+            lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
+
+  # Luftfeuchtigkeit
+  - platform: homeassistant
+    id: ha_weather_${num}_humidity
+    entity_id: ${entity_id}
+    attribute: humidity
+    internal: true
+
+  # Windgeschwindigkeit
+  - platform: homeassistant
+    id: ha_weather_${num}_wind_speed
+    entity_id: ${entity_id}
+    attribute: wind_speed
+    internal: true

--- a/src/templates/ha_weather.yaml
+++ b/src/templates/ha_weather.yaml
@@ -115,9 +115,9 @@ sensor:
             char buf[64];
             std::string weather_text = id(weather_${num}_state_text);
             if (weather_text.empty() || weather_text == "--") {
-              snprintf(buf, sizeof(buf), "--, %.1f °C", x);
+              snprintf(buf, sizeof(buf), "-- bei %.1f °C", x);
             } else {
-              snprintf(buf, sizeof(buf), "%s, %.1f °C", weather_text.c_str(), x);
+              snprintf(buf, sizeof(buf), "%s bei %.1f °C", weather_text.c_str(), x);
             }
             lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
 


### PR DESCRIPTION
## Zusammenfassung

Diese PR fügt eine Navigation Bar und Multi-Page-Support für das Display hinzu.

## Neue Features

### Navigation Bar
- Vor/Zurück-Buttons am unteren Displayrand
- Wrap-around Navigation (letzte Seite → erste Seite)
- Wird automatisch ausgeblendet bei Boot/OTA

### Neue Seiten
- **switches_page**: 6 Home Assistant Buttons im Grid-Layout (3x2)
- Page-Index-System für einfache Erweiterung

### Neue Templates
- **ha_weather.yaml**: Wetter-Entitäten mit deutschen Übersetzungen
  - Dynamische Icons basierend auf Wetterzustand
  - Temperaturanzeige
- **ha_button_entity.yaml**: Button-Entitäten (ohne Toggle-State)

## Verbesserungen

- OTA-Page Layout mit GRID-Struktur überarbeitet
- Boot-Page: Navigation wird korrekt ein-/ausgeblendet
- Neue Fonts: weather_icons (120px), roboto40, roboto90
- Chevron-Icons für Navigation
- Wetter-Entity (Slot 7) konfiguriert

## Geänderte Dateien
- `src/pages/navigation.yaml` (neu)
- `src/pages/switches.yaml` (neu)
- `src/templates/ha_weather.yaml` (neu)
- `src/templates/ha_button_entity.yaml` (neu)
- `src/common/core.yaml`
- `src/common/fonts.yaml`
- `src/common/homeassistant.yaml`
- `src/pages/boot.yaml`
- `src/pages/ota.yaml`
- `src/main.yaml`