### PR TITLE
chore: Bump ESPHome version to 2026.1.1

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -15,7 +15,7 @@ jobs:
       #### Modify below here to match your project ####
       files: |
         src/main.yaml
-      esphome-version: 2026.1.0
+      esphome-version: 2026.1.1
       #### Modify above here to match your project ####
 
       release-summary: ${{ github.event.release.body }}


### PR DESCRIPTION
## Zusammenfassung

Aktualisiert die ESPHome-Version im CI-Workflow von 2026.1.0 auf 2026.1.1.

## Änderungen

- `esphome-version: 2026.1.0` → `esphome-version: 2026.1.1`