### PR TITLE
feat: Add HA sensor integration for temperature display

### DIFF
--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -43,3 +43,9 @@ packages:
     vars:
       num: "7"
       entity_id: weather.wetter_garten
+  # Innentemperatur-Sensor verwendet Sensor-Template (ohne UI-Button)
+  ha_sensor_8: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "8"
+      entity_id: sensor.durchschnitts_innentemperatur

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -115,10 +115,7 @@ lvgl:
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
                               id: display_house_temp
-                              text: !lambda |-
-                                auto temp = id(ha_entity_8_state_text).state;
-                                if (temp.empty()) return std::string("-- °C");
-                                return temp + " °C";
+                              text: "-- °C"
                               text_font: roboto24
                               text_color: color_white
 

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -115,7 +115,10 @@ lvgl:
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
                               id: display_house_temp
-                              text: "-- °C"
+                              text: !lambda |-
+                                auto temp = id(ha_entity_8_state_text).state;
+                                if (temp.empty()) return std::string("-- °C");
+                                return temp + " °C";
                               text_font: roboto24
                               text_color: color_white
 

--- a/src/templates/ha_sensor.yaml
+++ b/src/templates/ha_sensor.yaml
@@ -44,4 +44,4 @@ text_sensor:
       if (pos != std::string::npos) {
         return entity_id.substr(0, pos);
       }
-      return std::string("unknown");;
+      return std::string("unknown");

--- a/src/templates/ha_sensor.yaml
+++ b/src/templates/ha_sensor.yaml
@@ -1,0 +1,47 @@
+# Template für Home Assistant Sensor Entity (ohne UI-Button)
+# Spezielles Template für reine Sensoren, die nur Text-Werte liefern
+# ohne zugehörigen LVGL-Button auf der Switches-Seite
+#
+# Variablen: num, entity_id
+# Liefert: State-Text, Domain, Friendly Name
+
+defaults:
+  num: "8"
+  entity_id: "sensor.placeholder"
+
+text_sensor:
+  # State Text (Sensor-Wert als String)
+  - platform: homeassistant
+    id: ha_entity_${num}_state_text
+    entity_id: ${entity_id}
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_sensor", "Sensor ${num} state: %s", x.c_str());
+        # LVGL Label aktualisieren wenn vorhanden
+        - lvgl.label.update:
+            id: display_house_temp
+            text: !lambda |-
+              std::string temp = id(ha_entity_${num}_state_text).state;
+              if (temp.empty()) return std::string("-- °C");
+              return temp + " °C";
+
+  # Friendly Name
+  - platform: homeassistant
+    id: ha_entity_${num}_friendly_name
+    entity_id: ${entity_id}
+    attribute: friendly_name
+    internal: true
+
+  # Domain (extrahiert aus entity_id)
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: |-
+      std::string entity_id = "${entity_id}";
+      size_t pos = entity_id.find('.');
+      if (pos != std::string::npos) {
+        return entity_id.substr(0, pos);
+      }
+      return std::string("unknown");;


### PR DESCRIPTION
- Create new ha_sensor.yaml template for sensor-only entities
- Update home.yaml to display house temperature from HA sensor
- Add sensor entity (ha_entity_8) to homeassistant.yaml config
- Update simulator with new sensor template

This adds support for displaying Home Assistant sensors like durchschnitts_innentemperatur on the home page display.