### PR TITLE
feat: Add temperature page with room sensors

### DIFF
--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -258,6 +258,7 @@
     "\U000F099E", # shield off
     "\U000F0498", # shield
     "\U000F0493", # settings
+    "\U000F058C", # water (humidity)
     "\U000F032A", # preset eco
     "\U000F0F9B", # preset away
     "\U000F14DE", # preset boost     

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -49,3 +49,43 @@ packages:
     vars:
       num: "8"
       entity_id: sensor.durchschnitts_innentemperatur
+  ha_sensor_9: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "9"
+      entity_id: sensor.bthome_sensor_081d_temperatur #Bad  
+  ha_sensor_10: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "10"
+      entity_id: sensor.bthome_sensor_081d_luftfeuchtigkeit #Bad  
+  ha_sensor_11: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "11"
+      entity_id: sensor.bthome_sensor_7920_temperatur #Wohnzimmer
+  ha_sensor_12: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "12"
+      entity_id: sensor.bthome_sensor_7920_luftfeuchtigkeit #Wohnzimmer
+  ha_sensor_13: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "13"
+      entity_id: sensor.bthome_sensor_d35e_temperatur #Schlafzimmer
+  ha_sensor_14: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "14"
+      entity_id: sensor.bthome_sensor_d35e_luftfeuchtigkeit #Schlafzimmer
+  ha_sensor_15: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "15"
+      entity_id: sensor.bthome_sensor_fccb_temperatur #Kueche
+  ha_sensor_16: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "16"
+      entity_id: sensor.bthome_sensor_fccb_luftfeuchtigkeit #Kueche

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -49,8 +49,9 @@ packages:
     vars:
       num: "8"
       entity_id: sensor.durchschnitts_innentemperatur
+  # Temperatur-Sensoren (9, 11, 13, 15) mit dynamischer Icon-Farbe
   ha_sensor_9: !include
-    file: ../templates/ha_sensor.yaml
+    file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "9"
       entity_id: sensor.bthome_sensor_081d_temperatur #Bad  
@@ -60,7 +61,7 @@ packages:
       num: "10"
       entity_id: sensor.bthome_sensor_081d_luftfeuchtigkeit #Bad  
   ha_sensor_11: !include
-    file: ../templates/ha_sensor.yaml
+    file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "11"
       entity_id: sensor.bthome_sensor_7920_temperatur #Wohnzimmer
@@ -70,7 +71,7 @@ packages:
       num: "12"
       entity_id: sensor.bthome_sensor_7920_luftfeuchtigkeit #Wohnzimmer
   ha_sensor_13: !include
-    file: ../templates/ha_sensor.yaml
+    file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "13"
       entity_id: sensor.bthome_sensor_d35e_temperatur #Schlafzimmer
@@ -80,7 +81,7 @@ packages:
       num: "14"
       entity_id: sensor.bthome_sensor_d35e_luftfeuchtigkeit #Schlafzimmer
   ha_sensor_15: !include
-    file: ../templates/ha_sensor.yaml
+    file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "15"
       entity_id: sensor.bthome_sensor_fccb_temperatur #Kueche

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -5,6 +5,7 @@ packages:
   boot_screen: !include pages/boot.yaml
   home_page: !include pages/home.yaml
   switches_page: !include pages/switches.yaml
+  temperatures_page: !include pages/temperatures.yaml
   ota_page: !include pages/ota.yaml
   navigation: !include pages/navigation.yaml
   theme: !include themes/modern.yaml

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -85,7 +85,7 @@ lvgl:
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
                               id: homeassistant_btn_7_label
-                              text: "°C --"
+                              text: "-- °C --"
                               text_font: roboto24
                               text_color: color_white
                     

--- a/src/pages/home.yaml
+++ b/src/pages/home.yaml
@@ -9,6 +9,10 @@ lvgl:
     - id: home_page
       bg_color: color_bg_dark
       widgets:
+        # Hidden placeholder für ha_sensor_label_8 (wird nur für Templates benötigt)
+        - label:
+            id: ha_sensor_label_8
+            hidden: true
         # Hintergrundbild
         - image:
             align: CENTER
@@ -81,7 +85,7 @@ lvgl:
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
                               id: homeassistant_btn_7_label
-                              text: "-- °C"
+                              text: "°C --"
                               text_font: roboto24
                               text_color: color_white
                     
@@ -114,7 +118,7 @@ lvgl:
                               grid_cell_row_pos: 0
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
-                              id: display_house_temp
+                              id: ha_temp_value_8
                               text: "-- °C"
                               text_font: roboto24
                               text_color: color_white

--- a/src/pages/navigation.yaml
+++ b/src/pages/navigation.yaml
@@ -16,7 +16,7 @@ globals:
   - id: total_pages
     type: int
     restore_value: no
-    initial_value: '2'
+    initial_value: '3'
 
 lvgl:
   top_layer:

--- a/src/pages/navigation.yaml
+++ b/src/pages/navigation.yaml
@@ -159,19 +159,27 @@ script:
                 condition:
                   lambda: 'return id(current_page_index) == 1;'
                 then:
-                  - lvgl.page.show: switches_page
+                  - lvgl.page.show: temperature_page
                   - lvgl.label.update:
                       id: page_name_label
-                      text: "Schalter"
+                      text: "Temperaturen"
                 else:
-                  # Fallback: Zurück zur Home-Seite
-                  - lambda: 'id(current_page_index) = 0;'
-                  - lvgl.page.show: home_page
-                  - lvgl.label.update:
-                      id: page_name_label
-                      text: "Home"
-
-  # Navigation Bar ein-/ausblenden
+                  - if:
+                      condition:
+                        lambda: 'return id(current_page_index) == 2;'
+                      then:
+                        - lvgl.page.show: switches_page
+                        - lvgl.label.update:
+                            id: page_name_label
+                            text: "Schalter"
+                      else:
+                        # Fallback: Zurück zur Home-Seite
+                        - lambda: 'id(current_page_index) = 0;'
+                        - lvgl.page.show: home_page
+                        - lvgl.label.update:
+                            id: page_name_label
+                            text: "Home"
+# Navigation Bar ein-/ausblenden
   - id: show_navigation
     then:
       - lvgl.widget.show: navigation_bar

--- a/src/pages/temperatures.yaml
+++ b/src/pages/temperatures.yaml
@@ -1,0 +1,56 @@
+# ========================================================================
+# TEMPERATURE PAGE - Raumtemperaturen Übersicht
+# ========================================================================
+# Design-Konzept: Moderne Cards mit farbigen Thermometer-Icons
+# 2x2 Grid für 4 Räume, Temperaturwert prominent angezeigt
+# ========================================================================
+
+lvgl:
+  pages:
+    - id: temperature_page
+      bg_color: color_bg_dark
+      widgets:
+        # Hintergrundbild
+        - image:
+            align: CENTER
+            src: see_img
+        
+        # Hidden placeholder für ha_sensor_label_8 (wird nur für Templates benötigt)
+        - label:
+            id: ha_sensor_label_10
+            hidden: true
+        
+        - label:
+            id: ha_sensor_label_12
+            hidden: true
+
+        - label:
+            id: ha_sensor_label_14
+            hidden: true
+        
+        - label:
+            id: ha_sensor_label_16
+            hidden: true
+
+        # Hauptcontainer mit 2x2 Grid
+        - obj:
+            layout:
+              type: GRID
+              grid_columns: [FR(1), FR(1)]
+              grid_rows: [FR(1), FR(1)]
+              pad_row: 16
+              pad_column: 16
+            width: 100%
+            height: ${content_height}
+            pad_all: 20
+            pad_top: 24
+            pad_bottom: 36
+            bg_opa: TRANSP
+            border_opa: TRANSP
+            widgets:
+              # Temperatur-Cards via Template-Include (col 0-1, row 0-1)
+              # Entity 9-12 sind die Temperatur-Sensoren (definiert in homeassistant.yaml)
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "9", hum: "10", col: "0", row: "0", icon_color: "color_secondary" } }
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "11", hum: "12", col: "1", row: "0", icon_color: "color_info" } }
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "13", hum: "14", col: "0", row: "1", icon_color: "color_secondary" } }
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "15", hum: "16", col: "1", row: "1", icon_color: "color_error" } }

--- a/src/pages/temperatures.yaml
+++ b/src/pages/temperatures.yaml
@@ -50,7 +50,8 @@ lvgl:
             widgets:
               # Temperatur-Cards via Template-Include (col 0-1, row 0-1)
               # Temperatur-Sensoren: Entities 9, 11, 13, 15; Feuchte-Sensoren: Entities 10, 12, 14, 16 (definiert in homeassistant.yaml)
-              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "9", hum: "10", col: "0", row: "0", icon_color: "color_secondary" } }
-              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "11", hum: "12", col: "1", row: "0", icon_color: "color_info" } }
-              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "13", hum: "14", col: "0", row: "1", icon_color: "color_secondary" } }
-              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "15", hum: "16", col: "1", row: "1", icon_color: "color_error" } }
+              # Icon-Farbe wird automatisch durch ha_temp_sensor.yaml basierend auf Temperatur gesetzt
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "9", hum: "10", col: "0", row: "0" } }
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "11", hum: "12", col: "1", row: "0" } }
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "13", hum: "14", col: "0", row: "1" } }
+              - !include { file: ../templates/ha_temp.yaml, vars: { temp: "15", hum: "16", col: "1", row: "1" } }

--- a/src/pages/temperatures.yaml
+++ b/src/pages/temperatures.yaml
@@ -15,7 +15,7 @@ lvgl:
             align: CENTER
             src: see_img
         
-        # Hidden placeholder für ha_sensor_label_8 (wird nur für Templates benötigt)
+        # Hidden placeholder für ha_sensor_label_10-16 (wird nur für Templates benötigt aber in der page nicht verwendet)
         - label:
             id: ha_sensor_label_10
             hidden: true
@@ -49,7 +49,7 @@ lvgl:
             border_opa: TRANSP
             widgets:
               # Temperatur-Cards via Template-Include (col 0-1, row 0-1)
-              # Entity 9-12 sind die Temperatur-Sensoren (definiert in homeassistant.yaml)
+              # Temperatur-Sensoren: Entities 9, 11, 13, 15; Feuchte-Sensoren: Entities 10, 12, 14, 16 (definiert in homeassistant.yaml)
               - !include { file: ../templates/ha_temp.yaml, vars: { temp: "9", hum: "10", col: "0", row: "0", icon_color: "color_secondary" } }
               - !include { file: ../templates/ha_temp.yaml, vars: { temp: "11", hum: "12", col: "1", row: "0", icon_color: "color_info" } }
               - !include { file: ../templates/ha_temp.yaml, vars: { temp: "13", hum: "14", col: "0", row: "1", icon_color: "color_secondary" } }

--- a/src/templates/ha_sensor.yaml
+++ b/src/templates/ha_sensor.yaml
@@ -21,7 +21,7 @@ text_sensor:
             ESP_LOGD("ha_sensor", "Sensor ${num} state: %s", x.c_str());
         # LVGL Label aktualisieren wenn vorhanden
         - lvgl.label.update:
-            id: display_house_temp
+            id: ha_temp_value_${num}
             text: !lambda |-
               std::string temp = id(ha_entity_${num}_state_text).state;
               if (temp.empty()) return std::string("-- °C");
@@ -33,6 +33,11 @@ text_sensor:
     entity_id: ${entity_id}
     attribute: friendly_name
     internal: true
+    on_value:
+      then:
+        - lvgl.label.update:
+            id: ha_sensor_label_${num}
+            text: !lambda return x.c_str();
 
   # Domain (extrahiert aus entity_id)
   - platform: template

--- a/src/templates/ha_sensor.yaml
+++ b/src/templates/ha_sensor.yaml
@@ -3,13 +3,24 @@
 # ohne zugehörigen LVGL-Button auf der Switches-Seite
 #
 # Variablen: num, entity_id
-# Liefert: State-Text, Domain, Friendly Name
+# Liefert: State-Text, Domain, Friendly Name, Unit of Measurement
 
 defaults:
   num: "8"
   entity_id: "sensor.placeholder"
 
 text_sensor:
+  # Unit of Measurement (Einheit aus Home Assistant)
+  - platform: homeassistant
+    id: ha_entity_${num}_unit
+    entity_id: ${entity_id}
+    attribute: unit_of_measurement
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_sensor", "Sensor ${num} unit: %s", x.c_str());
+
   # State Text (Sensor-Wert als String)
   - platform: homeassistant
     id: ha_entity_${num}_state_text
@@ -23,9 +34,16 @@ text_sensor:
         - lvgl.label.update:
             id: ha_temp_value_${num}
             text: !lambda |-
-              std::string temp = id(ha_entity_${num}_state_text).state;
-              if (temp.empty()) return std::string("-- °C");
-              return temp + " °C";
+              std::string value = id(ha_entity_${num}_state_text).state;
+              std::string unit = id(ha_entity_${num}_unit).state;
+              if (value.empty()) {
+                // Fallback mit Einheit oder Standardwert
+                if (unit.empty()) return std::string("--");
+                return std::string("-- ") + unit;
+              }
+              // Wert mit dynamischer Einheit zurückgeben
+              if (unit.empty()) return value;
+              return value + "" + unit;
 
   # Friendly Name
   - platform: homeassistant

--- a/src/templates/ha_temp.yaml
+++ b/src/templates/ha_temp.yaml
@@ -1,6 +1,7 @@
 # Template für Home Assistant Temperatur-Sensor Widget (LVGL Card)
 # Variablen: temp, col, row, icon_color (optional)
-# Die Entity-ID wird dynamisch aus dem Text-Sensor ha_entity_${temp}_id gelesen
+# Der Anzeigename wird dynamisch aus dem Text-Sensor ha_entity_${temp}_friendly_name gelesen
+# Temperatur- und Feuchtewerte werden über die Labels ha_temp_value_${temp} / ha_temp_value_${hum} aktualisiert
 # Design: Glassmorphism Card mit farbigem Thermometer-Icon links, Name + Wert rechts
 
 defaults:
@@ -97,7 +98,7 @@ obj:
                 pad_right: 6
             - label:
                 id: ha_temp_value_${hum}
-                text: "72 %"
+                text: "-- %"
                 text_font: roboto16
                 text_color: color_gray_300
 

--- a/src/templates/ha_temp.yaml
+++ b/src/templates/ha_temp.yaml
@@ -9,7 +9,6 @@ defaults:
   hum: "9"
   col: "0"
   row: "0"
-  icon_color: "color_secondary"
 
 obj:
   id: temp_card_${temp}
@@ -38,7 +37,7 @@ obj:
     pad_row: 4
     pad_column: 12
   widgets:
-    # Thermometer Icon (farbig)
+    # Thermometer Icon (Farbe wird dynamisch durch ha_temp_sensor.yaml aktualisiert)
     - label:
         id: temp_icon_${temp}
         grid_cell_column_pos: 0
@@ -48,7 +47,7 @@ obj:
         grid_cell_y_align: CENTER
         text: "\U000F050F"
         text_font: btn_icons_font
-        text_color: ${icon_color}
+        text_color: color_gray_500
     # Raumname (aus friendly_name)
     - label:
         id: ha_sensor_label_${temp}

--- a/src/templates/ha_temp.yaml
+++ b/src/templates/ha_temp.yaml
@@ -1,0 +1,106 @@
+# Template für Home Assistant Temperatur-Sensor Widget (LVGL Card)
+# Variablen: temp, col, row, icon_color (optional)
+# Die Entity-ID wird dynamisch aus dem Text-Sensor ha_entity_${temp}_id gelesen
+# Design: Glassmorphism Card mit farbigem Thermometer-Icon links, Name + Wert rechts
+
+defaults:
+  temp: "8"
+  hum: "9"
+  col: "0"
+  row: "0"
+  icon_color: "color_secondary"
+
+obj:
+  id: temp_card_${temp}
+  grid_cell_column_pos: ${col}
+  grid_cell_row_pos: ${row}
+  grid_cell_x_align: STRETCH
+  grid_cell_y_align: STRETCH
+  # Glassmorphism Card Styling
+  radius: 24
+  bg_color: color_gray_800
+  bg_opa: 60%
+  border_color: color_gray_600
+  border_width: 1
+  border_opa: 20%
+  shadow_width: 16
+  shadow_ofs_y: 6
+  shadow_color: color_black
+  shadow_opa: 35%
+  pad_all: 16
+  scrollbar_mode: "OFF"
+  # Grid Layout für Icon + Name/Wert
+  layout:
+    type: GRID
+    grid_columns: [48, FR(1)]
+    grid_rows: [SIZE_CONTENT, 6, SIZE_CONTENT, SIZE_CONTENT]
+    pad_row: 4
+    pad_column: 12
+  widgets:
+    # Thermometer Icon (farbig)
+    - label:
+        id: temp_icon_${temp}
+        grid_cell_column_pos: 0
+        grid_cell_row_pos: 0
+        grid_cell_row_span: 4
+        grid_cell_x_align: CENTER
+        grid_cell_y_align: CENTER
+        text: "\U000F050F"
+        text_font: btn_icons_font
+        text_color: ${icon_color}
+    # Raumname (aus friendly_name)
+    - label:
+        id: ha_sensor_label_${temp}
+        grid_cell_column_pos: 1
+        grid_cell_row_pos: 0
+        grid_cell_x_align: START
+        grid_cell_y_align: CENTER
+        text: !lambda |-
+          if (id(ha_entity_${temp}_friendly_name).has_state()) {
+            return id(ha_entity_${temp}_friendly_name).state;
+          }
+          return std::string("Sensor ${temp}");
+        text_font: roboto16
+        text_color: color_gray_300
+    # Temperaturwert (groß)
+    - label:
+        id: ha_temp_value_${temp}
+        grid_cell_column_pos: 1
+        grid_cell_row_pos: 2
+        grid_cell_x_align: START
+        grid_cell_y_align: CENTER
+        text: "-- °C"
+        text_font: roboto24
+        text_color: color_white
+    
+    # Luftfeuchtigkeit
+    - obj:
+        grid_cell_column_pos: 1
+        grid_cell_row_pos: 3
+        grid_cell_x_align: START
+        grid_cell_y_align: START
+        width: SIZE_CONTENT
+        height: SIZE_CONTENT
+        bg_opa: TRANSP
+        border_opa: TRANSP
+        pad_all: 0
+        layout:
+            type: FLEX
+            flex_flow: ROW
+            flex_align_main: START
+            flex_align_cross: CENTER
+        widgets:
+            - label:
+                text: "\U000F058C"
+                text_font: mdi_icons_24
+                text_color: color_info
+                pad_right: 6
+            - label:
+                id: ha_temp_value_${hum}
+                text: "72 %"
+                text_font: roboto16
+                text_color: color_gray_300
+
+
+
+                    

--- a/src/templates/ha_temp_sensor.yaml
+++ b/src/templates/ha_temp_sensor.yaml
@@ -1,0 +1,94 @@
+# Template für Home Assistant Temperatur-Sensor Entity (mit Icon-Farb-Update)
+# Spezielles Template für Temperatur-Sensoren mit dynamischer Icon-Farbe
+# basierend auf dem Temperaturwert
+#
+# Variablen: num, entity_id
+# Liefert: State-Text, Domain, Friendly Name, Unit of Measurement
+# Aktualisiert: temp_icon_${num} mit temperaturabhängiger Farbe
+#
+# Farbskala:
+#   < 16°C  → Blau (color_info) - Kalt
+#   16-22°C → Grün (color_success) - Angenehm
+#   22-26°C → Orange (color_warning) - Warm
+#   > 26°C  → Rot (color_error) - Heiß
+
+defaults:
+  num: "8"
+  entity_id: "sensor.placeholder"
+
+text_sensor:
+  # Unit of Measurement (Einheit aus Home Assistant)
+  - platform: homeassistant
+    id: ha_entity_${num}_unit
+    entity_id: ${entity_id}
+    attribute: unit_of_measurement
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_temp_sensor", "Sensor ${num} unit: %s", x.c_str());
+
+  # State Text (Sensor-Wert als String)
+  - platform: homeassistant
+    id: ha_entity_${num}_state_text
+    entity_id: ${entity_id}
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_temp_sensor", "Sensor ${num} state: %s", x.c_str());
+        # LVGL Label aktualisieren
+        - lvgl.label.update:
+            id: ha_temp_value_${num}
+            text: !lambda |-
+              std::string value = id(ha_entity_${num}_state_text).state;
+              std::string unit = id(ha_entity_${num}_unit).state;
+              if (value.empty()) {
+                if (unit.empty()) return std::string("--");
+                return std::string("-- ") + unit;
+              }
+              if (unit.empty()) return value;
+              return value + " " + unit;
+        # Icon-Farbe basierend auf Temperaturwert aktualisieren
+        - lvgl.widget.update:
+            id: temp_icon_${num}
+            text_color: !lambda |-
+              std::string value_str = id(ha_entity_${num}_state_text).state;
+              if (value_str.empty()) return id(color_gray_500);
+              
+              float temp = atof(value_str.c_str());
+              
+              // Farbskala: Kalt → Angenehm → Warm → Heiß
+              if (temp < 16.0f) {
+                return id(color_info);      // Blau - Kalt
+              } else if (temp < 22.0f) {
+                return id(color_success);   // Grün - Angenehm
+              } else if (temp < 26.0f) {
+                return id(color_warning);   // Orange - Warm
+              } else {
+                return id(color_error);     // Rot - Heiß
+              }
+
+  # Friendly Name
+  - platform: homeassistant
+    id: ha_entity_${num}_friendly_name
+    entity_id: ${entity_id}
+    attribute: friendly_name
+    internal: true
+    on_value:
+      then:
+        - lvgl.label.update:
+            id: ha_sensor_label_${num}
+            text: !lambda return x.c_str();
+
+  # Domain (extrahiert aus entity_id)
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: |-
+      std::string entity_id = "${entity_id}";
+      size_t pos = entity_id.find('.');
+      if (pos != std::string::npos) {
+        return entity_id.substr(0, pos);
+      }
+      return std::string("unknown");

--- a/src/templates/ha_temp_sensor.yaml
+++ b/src/templates/ha_temp_sensor.yaml
@@ -48,16 +48,32 @@ text_sensor:
                 return std::string("-- ") + unit;
               }
               if (unit.empty()) return value;
-              return value + " " + unit;
+              return value + "" + unit;
         # Icon-Farbe basierend auf Temperaturwert aktualisieren
         - lvgl.widget.update:
             id: temp_icon_${num}
             text_color: !lambda |-
               std::string value_str = id(ha_entity_${num}_state_text).state;
               if (value_str.empty()) return id(color_gray_500);
-              
-              float temp = atof(value_str.c_str());
-              
+
+              const char *cstr = value_str.c_str();
+              char *endptr = nullptr;
+              float temp = strtof(cstr, &endptr);
+
+              // Prüfen, ob überhaupt etwas geparst wurde
+              if (cstr == endptr) {
+                return id(color_gray_500);
+              }
+
+              // Optionale nachfolgende Whitespaces überspringen
+              while (*endptr == ' ' || *endptr == '\t') {
+                ++endptr;
+              }
+
+              // Wenn noch nicht das Stringende erreicht ist, ist der Wert nicht rein numerisch
+              if (*endptr != '\0') {
+                return id(color_gray_500);
+              }
               // Farbskala: Kalt → Angenehm → Warm → Heiß
               if (temp < 16.0f) {
                 return id(color_info);      // Blau - Kalt

--- a/src/templates/ha_weather.yaml
+++ b/src/templates/ha_weather.yaml
@@ -81,9 +81,9 @@ text_sensor:
             // Kombiniertes Label aktualisieren
             char buf[64];
             if (std::isnan(id(weather_${num}_temp_value))) {
-              snprintf(buf, sizeof(buf), "%s bei -- °C", translated.c_str());
+              snprintf(buf, sizeof(buf), "-- °C %s", translated.c_str());
             } else {
-              snprintf(buf, sizeof(buf), "%s bei %.1f °C", translated.c_str(), id(weather_${num}_temp_value));
+              snprintf(buf, sizeof(buf), "%.1f °C %s", id(weather_${num}_temp_value), translated.c_str());
             }
             if (lv_is_initialized()) {
               lv_label_set_text(id(homeassistant_btn_${num}_label), buf);
@@ -119,9 +119,9 @@ sensor:
             char buf[64];
             std::string weather_text = id(weather_${num}_state_text);
             if (weather_text.empty() || weather_text == "--") {
-              snprintf(buf, sizeof(buf), "-- bei %.1f °C", x);
+              snprintf(buf, sizeof(buf), "%.1f °C --", x);
             } else {
-              snprintf(buf, sizeof(buf), "%s bei %.1f °C", weather_text.c_str(), x);
+              snprintf(buf, sizeof(buf), "%.1f °C %s", x, weather_text.c_str());
             }
             if (lv_is_initialized()) {
               lv_label_set_text(id(homeassistant_btn_${num}_label), buf);

--- a/tests/simulator/main.simulator.yaml
+++ b/tests/simulator/main.simulator.yaml
@@ -311,6 +311,7 @@ font:
     glyphs: [
       "\U000F0599", # weather-sunny
       "\U000F050F", # thermometer
+      "\U000F058C", # water-percent (humidity)
     ]
   
   # Button Icons Font (64px für große Buttons)
@@ -382,7 +383,7 @@ globals:
   - id: total_pages
     type: int
     restore_value: no
-    initial_value: '2'
+    initial_value: '3'
   # Mock HA Connection Status (startet mit false für Bootscreen)
   - id: ha_connected
     type: bool
@@ -546,6 +547,119 @@ text_sensor:
     internal: true
     lambda: return std::string("weather");
 
+  # Entity 8 - Raumtemperatur Wohnzimmer (ha_sensor Template)
+  - platform: template
+    id: ha_entity_8_state_text
+    internal: true
+    lambda: return std::string("21.5");
+  - platform: template
+    id: ha_entity_8_friendly_name
+    internal: true
+    lambda: return std::string("Wohnzimmer Temperatur");
+  - platform: template
+    id: ha_entity_8_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 9 - Raumtemperatur Schlafzimmer (ha_sensor Template)
+  - platform: template
+    id: ha_entity_9_state_text
+    internal: true
+    lambda: return std::string("19.8");
+  - platform: template
+    id: ha_entity_9_friendly_name
+    internal: true
+    lambda: return std::string("Schlafzimmer Temperatur");
+  - platform: template
+    id: ha_entity_9_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 10 - Raumtemperatur Küche (ha_sensor Template)
+  - platform: template
+    id: ha_entity_10_state_text
+    internal: true
+    lambda: return std::string("22.3");
+  - platform: template
+    id: ha_entity_10_friendly_name
+    internal: true
+    lambda: return std::string("Küche Temperatur");
+  - platform: template
+    id: ha_entity_10_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 11 - Raumtemperatur Bad (ha_sensor Template)
+  - platform: template
+    id: ha_entity_11_state_text
+    internal: true
+    lambda: return std::string("24.1");
+  - platform: template
+    id: ha_entity_11_friendly_name
+    internal: true
+    lambda: return std::string("Bad Temperatur");
+  - platform: template
+    id: ha_entity_11_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 13 - Luftfeuchtigkeit Wohnzimmer
+  - platform: template
+    id: ha_entity_13_state_text
+    internal: true
+    lambda: return std::string("58");
+  - platform: template
+    id: ha_entity_13_friendly_name
+    internal: true
+    lambda: return std::string("Wohnzimmer Luftfeuchtigkeit");
+  - platform: template
+    id: ha_entity_13_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 14 - Luftfeuchtigkeit Schlafzimmer
+  - platform: template
+    id: ha_entity_14_state_text
+    internal: true
+    lambda: return std::string("62");
+  - platform: template
+    id: ha_entity_14_friendly_name
+    internal: true
+    lambda: return std::string("Schlafzimmer Luftfeuchtigkeit");
+  - platform: template
+    id: ha_entity_14_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 15 - Luftfeuchtigkeit Küche
+  - platform: template
+    id: ha_entity_15_state_text
+    internal: true
+    lambda: return std::string("65");
+  - platform: template
+    id: ha_entity_15_friendly_name
+    internal: true
+    lambda: return std::string("Küche Luftfeuchtigkeit");
+  - platform: template
+    id: ha_entity_15_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+  # Entity 16 - Luftfeuchtigkeit Bad
+  - platform: template
+    id: ha_entity_16_state_text
+    internal: true
+    lambda: return std::string("72");
+  - platform: template
+    id: ha_entity_16_friendly_name
+    internal: true
+    lambda: return std::string("Bad Luftfeuchtigkeit");
+  - platform: template
+    id: ha_entity_16_domain
+    internal: true
+    lambda: return std::string("sensor");
+
+
 # ============================================================================
 # Scripts
 # ============================================================================
@@ -634,24 +748,30 @@ script:
             return std::string(buf);
 
   # Navigation Scripts
+  # Navigation zur vorherigen Seite
   - id: navigate_prev
     then:
       - lambda: |-
           int current = id(current_page_index);
           int total = id(total_pages);
+          // Wrap-around: von 0 zurück zu letzter Seite
           current = (current - 1 + total) % total;
           id(current_page_index) = current;
       - script.execute: show_current_page
 
+  # Navigation zur nächsten Seite
   - id: navigate_next
     then:
       - lambda: |-
           int current = id(current_page_index);
           int total = id(total_pages);
+          // Wrap-around: von letzter Seite weiter zu 0
           current = (current + 1) % total;
           id(current_page_index) = current;
       - script.execute: show_current_page
 
+  # Aktuelle Seite basierend auf Index anzeigen
+  # Page-Name wird direkt hier gesetzt (Single Source of Truth)
   - id: show_current_page
     then:
       - if:
@@ -659,16 +779,36 @@ script:
             lambda: 'return id(current_page_index) == 0;'
           then:
             - lvgl.page.show: home_page
+            - lvgl.label.update:
+                id: page_name_label
+                text: "Home"
           else:
             - if:
                 condition:
                   lambda: 'return id(current_page_index) == 1;'
                 then:
                   - lvgl.page.show: switches_page
+                  - lvgl.label.update:
+                      id: page_name_label
+                      text: "Schalter"
                 else:
-                  - lambda: 'id(current_page_index) = 0;'
-                  - lvgl.page.show: home_page
+                  - if:
+                      condition:
+                        lambda: 'return id(current_page_index) == 2;'
+                      then:
+                        - lvgl.page.show: temperature_page
+                        - lvgl.label.update:
+                            id: page_name_label
+                            text: "Temperaturen"
+                      else:
+                        # Fallback: Zurück zur Home-Seite
+                        - lambda: 'id(current_page_index) = 0;'
+                        - lvgl.page.show: home_page
+                        - lvgl.label.update:
+                            id: page_name_label
+                            text: "Home"
 
+  # Navigation Bar ein-/ausblenden
   - id: show_navigation
     then:
       - lvgl.widget.show: navigation_bar
@@ -676,6 +816,18 @@ script:
   - id: hide_navigation
     then:
       - lvgl.widget.hide: navigation_bar
+
+  # Navigation zu bestimmter Seite (Index)
+  - id: navigate_to_page
+    parameters:
+      page_index: int
+    then:
+      - lambda: |-
+          int total = id(total_pages);
+          if (page_index >= 0 && page_index < total) {
+            id(current_page_index) = page_index;
+          }
+      - script.execute: show_current_page
 
 # Zeit-Simulation: Jede Minute erhöhen
 interval:
@@ -1119,18 +1271,30 @@ lvgl:
           align: BOTTOM_MID
           y: -12
           width: 460
-          height: 56
-          styles: nav_bar_modern
+          height: 64
+          radius: 20
+          bg_color: color_gray_900
+          bg_opa: 80%
+          border_color: color_gray_600
+          border_width: 1
+          border_opa: 30%
+          shadow_width: 16
+          shadow_ofs_y: -4
+          shadow_color: color_black
+          shadow_opa: 40%
+          pad_all: 8
+          pad_left: 12
+          pad_right: 12
           hidden: true
           scrollbar_mode: "OFF"
           layout:
             type: GRID
-            grid_columns: [FR(1), FR(2), FR(1)]
+            grid_columns: [48, FR(1), 48]
             grid_rows: [FR(1)]
             pad_row: 0
-            pad_column: 8
+            pad_column: 12
           widgets:
-            # Zurück-Button
+            # Zurück-Button (links)
             - button:
                 id: nav_btn_prev
                 grid_cell_column_pos: 0
@@ -1152,53 +1316,20 @@ lvgl:
                       id: nav_btn_prev_icon
                       align: CENTER
                       text_font: mdi_icons_40
-                      text: "\U000F0141"
                       text_color: color_gray_300
 
-            # Page Indicator (Mitte)
-            - obj:
+            # Page Name (Mitte)
+            - label:
+                id: page_name_label
                 grid_cell_column_pos: 1
                 grid_cell_row_pos: 0
                 grid_cell_x_align: CENTER
                 grid_cell_y_align: CENTER
-                width: 80
-                height: 8
-                bg_opa: TRANSP
-                border_opa: TRANSP
-                layout:
-                  type: GRID
-                  grid_columns: [FR(1), FR(1)]
-                  grid_rows: [FR(1)]
-                  pad_column: 8
-                widgets:
-                  # Dot 1
-                  - obj:
-                      id: page_dot_1
-                      grid_cell_column_pos: 0
-                      grid_cell_row_pos: 0
-                      grid_cell_x_align: CENTER
-                      grid_cell_y_align: CENTER
-                      width: 32
-                      height: 6
-                      radius: 3
-                      bg_color: color_primary
-                      bg_opa: COVER
-                      border_opa: TRANSP
-                  # Dot 2
-                  - obj:
-                      id: page_dot_2
-                      grid_cell_column_pos: 1
-                      grid_cell_row_pos: 0
-                      grid_cell_x_align: CENTER
-                      grid_cell_y_align: CENTER
-                      width: 8
-                      height: 6
-                      radius: 3
-                      bg_color: color_gray_600
-                      bg_opa: COVER
-                      border_opa: TRANSP
+                text: "Home"
+                text_font: roboto24
+                text_color: color_white
 
-            # Vor-Button
+            # Vor-Button (rechts)
             - button:
                 id: nav_btn_next
                 grid_cell_column_pos: 2
@@ -1220,8 +1351,8 @@ lvgl:
                       id: nav_btn_next_icon
                       align: CENTER
                       text_font: mdi_icons_40
-                      text: "\U000F0142"
                       text_color: color_gray_300
+
 
   # Seiten
   pages:
@@ -1306,7 +1437,7 @@ lvgl:
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
                               id: homeassistant_btn_7_label
-                              text: "22°C  Sonnig"
+                              text: "°C --"
                               text_font: roboto24
                               text_color: color_white
                     
@@ -1340,7 +1471,7 @@ lvgl:
                               grid_cell_x_align: START
                               grid_cell_y_align: CENTER
                               id: display_house_temp
-                              text: "21.5°C"
+                              text: "-- °C"
                               text_font: roboto24
                               text_color: color_white
 
@@ -1400,26 +1531,7 @@ lvgl:
         - image:
             align: CENTER
             src: see_img
-        
-        # Page Title mit Backdrop
-        - obj:
-            align: TOP_MID
-            y: 12
-            width: SIZE_CONTENT
-            height: 40
-            pad_left: 20
-            pad_right: 20
-            radius: 20
-            bg_color: color_bg_dark
-            bg_opa: 70%
-            border_opa: TRANSP
-            widgets:
-              - label:
-                  align: CENTER
-                  text: "Geräte"
-                  text_font: roboto24
-                  text_color: color_white
-        
+
         # Hauptcontainer mit 2x3 Grid
         - obj:
             layout:
@@ -1429,10 +1541,10 @@ lvgl:
               pad_row: 16
               pad_column: 16
             width: 100%
-            height: 340
-            y: 48
+            height: ${content_height}
             pad_all: 20
             pad_top: 24
+            pad_bottom: 36
             bg_opa: TRANSP
             border_opa: TRANSP
             widgets:
@@ -1695,3 +1807,382 @@ lvgl:
                         text: "Rollladen"
                         text_font: roboto16
                         text_color: color_gray_200
+
+    # ========================================================================
+    # TEMPERATURE PAGE - Raumtemperaturen Übersicht
+    # ========================================================================
+    # Design-Konzept: Moderne Cards mit farbigen Thermometer-Icons
+    # 2x2 Grid für 4 Räume, Temperaturwert prominent angezeigt
+    # ========================================================================
+    - id: temperature_page
+      bg_color: color_bg_dark
+      widgets:
+        # Hintergrundbild
+        - image:
+            align: CENTER
+            src: see_img
+
+        # Hauptcontainer mit 2x2 Grid
+        - obj:
+            layout:
+              type: GRID
+              grid_columns: [FR(1), FR(1)]
+              grid_rows: [FR(1), FR(1)]
+              pad_row: 16
+              pad_column: 16
+            width: 100%
+            height: ${content_height}
+            pad_all: 20
+            pad_top: 24
+            pad_bottom: 36
+            bg_opa: TRANSP
+            border_opa: TRANSP
+            widgets:
+              # ============================================================
+              # Card 1 - Wohnzimmer Temperatur (oben links)
+              # ============================================================
+              - obj:
+                  id: temp_card_wohnzimmer
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 0
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 24
+                  bg_color: color_gray_800
+                  bg_opa: 60%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 20%
+                  shadow_width: 16
+                  shadow_ofs_y: 6
+                  shadow_color: color_black
+                  shadow_opa: 35%
+                  pad_all: 20
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [60, FR(1)]
+                    grid_rows: [SIZE_CONTENT, 6, SIZE_CONTENT, SIZE_CONTENT]
+                    pad_row: 0
+                    pad_column: 12
+                  widgets:
+                    # Thermometer Icon (farbig - Orange/Warm)
+                    - label:
+                        id: temp_icon_8
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_row_span: 4
+                        grid_cell_x_align: CENTER
+                        grid_cell_y_align: CENTER
+                        text: "\U000F050F"
+                        text_font: btn_icons_font
+                        text_color: color_secondary
+                    # Raumname (oben)
+                    - label:
+                        id: temp_label_8
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "Wohnzimmer"
+                        text_font: roboto16
+                        text_color: color_gray_300
+                    # Spacer (Zeile 1 = 6px)
+                    # Temperaturwert
+                    - label:
+                        id: temp_value_8
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 2
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "21.5 °C"
+                        text_font: roboto24
+                        text_color: color_white
+                    # Luftfeuchtigkeit (direkt unter Temperatur)
+                    - obj:
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 3
+                        grid_cell_x_align: START
+                        grid_cell_y_align: START
+                        width: SIZE_CONTENT
+                        height: SIZE_CONTENT
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        pad_all: 0
+                        layout:
+                          type: FLEX
+                          flex_flow: ROW
+                          flex_align_main: START
+                          flex_align_cross: CENTER
+                        widgets:
+                          - label:
+                              text: "\U000F058C"
+                              text_font: mdi_icons_24
+                              text_color: color_info
+                              pad_right: 6
+                          - label:
+                              id: humidity_value_8
+                              text: "58 %"
+                              text_font: roboto16
+                              text_color: color_gray_300
+
+              # ============================================================
+              # Card 2 - Schlafzimmer Temperatur (oben rechts)
+              # ============================================================
+              - obj:
+                  id: temp_card_schlafzimmer
+                  grid_cell_column_pos: 1
+                  grid_cell_row_pos: 0
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 24
+                  bg_color: color_gray_800
+                  bg_opa: 60%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 20%
+                  shadow_width: 16
+                  shadow_ofs_y: 6
+                  shadow_color: color_black
+                  shadow_opa: 35%
+                  pad_all: 20
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [60, FR(1)]
+                    grid_rows: [SIZE_CONTENT, 6, SIZE_CONTENT, SIZE_CONTENT]
+                    pad_row: 0
+                    pad_column: 12
+                  widgets:
+                    # Thermometer Icon (farbig - Blau/Kühl)
+                    - label:
+                        id: temp_icon_9
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_row_span: 4
+                        grid_cell_x_align: CENTER
+                        grid_cell_y_align: CENTER
+                        text: "\U000F050F"
+                        text_font: btn_icons_font
+                        text_color: color_info
+                    # Raumname
+                    - label:
+                        id: temp_label_9
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "Schlafzimmer"
+                        text_font: roboto16
+                        text_color: color_gray_300
+                    # Temperaturwert
+                    - label:
+                        id: temp_value_9
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 2
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "19.8 °C"
+                        text_font: roboto24
+                        text_color: color_white
+                    # Luftfeuchtigkeit
+                    - obj:
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 3
+                        grid_cell_x_align: START
+                        grid_cell_y_align: START
+                        width: SIZE_CONTENT
+                        height: SIZE_CONTENT
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        pad_all: 0
+                        layout:
+                          type: FLEX
+                          flex_flow: ROW
+                          flex_align_main: START
+                          flex_align_cross: CENTER
+                        widgets:
+                          - label:
+                              text: "\U000F058C"
+                              text_font: mdi_icons_24
+                              text_color: color_info
+                              pad_right: 6
+                          - label:
+                              id: humidity_value_9
+                              text: "62 %"
+                              text_font: roboto16
+                              text_color: color_gray_300
+
+              # ============================================================
+              # Card 3 - Küche Temperatur (unten links)
+              # ============================================================
+              - obj:
+                  id: temp_card_kueche
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 1
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 24
+                  bg_color: color_gray_800
+                  bg_opa: 60%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 20%
+                  shadow_width: 16
+                  shadow_ofs_y: 6
+                  shadow_color: color_black
+                  shadow_opa: 35%
+                  pad_all: 20
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [60, FR(1)]
+                    grid_rows: [SIZE_CONTENT, 6, SIZE_CONTENT, SIZE_CONTENT]
+                    pad_row: 0
+                    pad_column: 12
+                  widgets:
+                    # Thermometer Icon (farbig - Orange/Warm)
+                    - label:
+                        id: temp_icon_10
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_row_span: 4
+                        grid_cell_x_align: CENTER
+                        grid_cell_y_align: CENTER
+                        text: "\U000F050F"
+                        text_font: btn_icons_font
+                        text_color: color_secondary
+                    # Raumname
+                    - label:
+                        id: temp_label_10
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "Küche"
+                        text_font: roboto16
+                        text_color: color_gray_300
+                    # Temperaturwert
+                    - label:
+                        id: temp_value_10
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 2
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "22.3 °C"
+                        text_font: roboto24
+                        text_color: color_white
+                    # Luftfeuchtigkeit
+                    - obj:
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 3
+                        grid_cell_x_align: START
+                        grid_cell_y_align: START
+                        width: SIZE_CONTENT
+                        height: SIZE_CONTENT
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        pad_all: 0
+                        layout:
+                          type: FLEX
+                          flex_flow: ROW
+                          flex_align_main: START
+                          flex_align_cross: CENTER
+                        widgets:
+                          - label:
+                              text: "\U000F058C"
+                              text_font: mdi_icons_24
+                              text_color: color_info
+                              pad_right: 6
+                          - label:
+                              id: humidity_value_10
+                              text: "65 %"
+                              text_font: roboto16
+                              text_color: color_gray_300
+
+              # ============================================================
+              # Card 4 - Bad Temperatur (unten rechts)
+              # ============================================================
+              - obj:
+                  id: temp_card_bad
+                  grid_cell_column_pos: 1
+                  grid_cell_row_pos: 1
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 24
+                  bg_color: color_gray_800
+                  bg_opa: 60%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 20%
+                  shadow_width: 16
+                  shadow_ofs_y: 6
+                  shadow_color: color_black
+                  shadow_opa: 35%
+                  pad_all: 20
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [60, FR(1)]
+                    grid_rows: [SIZE_CONTENT, 6, SIZE_CONTENT, SIZE_CONTENT]
+                    pad_row: 0
+                    pad_column: 12
+                  widgets:
+                    # Thermometer Icon (farbig - Rot/Warm)
+                    - label:
+                        id: temp_icon_11
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_row_span: 4
+                        grid_cell_x_align: CENTER
+                        grid_cell_y_align: CENTER
+                        text: "\U000F050F"
+                        text_font: btn_icons_font
+                        text_color: color_error
+                    # Raumname
+                    - label:
+                        id: temp_label_11
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "Bad"
+                        text_font: roboto16
+                        text_color: color_gray_300
+                    # Temperaturwert
+                    - label:
+                        id: temp_value_11
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 2
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        text: "24.1 °C"
+                        text_font: roboto24
+                        text_color: color_white
+                    # Luftfeuchtigkeit
+                    - obj:
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 3
+                        grid_cell_x_align: START
+                        grid_cell_y_align: START
+                        width: SIZE_CONTENT
+                        height: SIZE_CONTENT
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        pad_all: 0
+                        layout:
+                          type: FLEX
+                          flex_flow: ROW
+                          flex_align_main: START
+                          flex_align_cross: CENTER
+                        widgets:
+                          - label:
+                              text: "\U000F058C"
+                              text_font: mdi_icons_24
+                              text_color: color_info
+                              pad_right: 6
+                          - label:
+                              id: humidity_value_11
+                              text: "72 %"
+                              text_font: roboto16
+                              text_color: color_gray_300


### PR DESCRIPTION
## 🌡️ Temperature Page Feature

### Übersicht
Diese PR fügt eine neue Temperatur-Seite hinzu, die Raumtemperaturen und Luftfeuchtigkeit für 4 Räume anzeigt.

### Änderungen

#### Neue Dateien
- `src/pages/temperatures.yaml` - Neue Seite mit 2x2 Grid-Layout
- `src/templates/ha_temp.yaml` - Wiederverwendbares Template für Temperatur-Cards

#### Modifizierte Dateien
- `src/common/homeassistant.yaml` - 8 neue Sensoren (Temp + Humidity pro Raum)
- `src/pages/navigation.yaml` - Navigation auf 3 Seiten erweitert
- `src/common/fonts.yaml` - Humidity-Icon hinzugefügt
- `src/templates/ha_weather.yaml` - Wetter-Anzeige Format verbessert
- `src/templates/ha_sensor.yaml` - Label-Update für dynamische Namen
- `tests/simulator/main.simulator.yaml` - Mock-Daten für Simulator

### Räume & Sensoren
| Raum | Temperatur | Luftfeuchtigkeit |
|------|------------|------------------|
| Bad | Sensor 9 | Sensor 10 |
| Wohnzimmer | Sensor 11 | Sensor 12 |
| Schlafzimmer | Sensor 13 | Sensor 14 |
| Küche | Sensor 15 | Sensor 16 |

### Design
- Glassmorphism Cards mit farbigen Thermometer-Icons
- Kompaktes 2x2 Grid-Layout
- Temperatur prominent, Luftfeuchtigkeit als Subtext