### PR TITLE
fix: Room name display in temperature cards

### DIFF
--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -54,6 +54,7 @@ packages:
     file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "9"
+      room: "Bad"
       entity_id: sensor.bthome_sensor_081d_temperatur #Bad  
   ha_sensor_10: !include
     file: ../templates/ha_sensor.yaml
@@ -64,6 +65,7 @@ packages:
     file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "11"
+      room: "Wohnzimmer"
       entity_id: sensor.bthome_sensor_7920_temperatur #Wohnzimmer
   ha_sensor_12: !include
     file: ../templates/ha_sensor.yaml
@@ -74,6 +76,7 @@ packages:
     file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "13"
+      room: "Schlafzimmer"
       entity_id: sensor.bthome_sensor_d35e_temperatur #Schlafzimmer
   ha_sensor_14: !include
     file: ../templates/ha_sensor.yaml
@@ -84,6 +87,7 @@ packages:
     file: ../templates/ha_temp_sensor.yaml
     vars:
       num: "15"
+      room: "Küche"
       entity_id: sensor.bthome_sensor_fccb_temperatur #Kueche
   ha_sensor_16: !include
     file: ../templates/ha_sensor.yaml

--- a/src/templates/ha_temp.yaml
+++ b/src/templates/ha_temp.yaml
@@ -48,7 +48,7 @@ obj:
         text: "\U000F050F"
         text_font: btn_icons_font
         text_color: color_gray_500
-    # Raumname (aus friendly_name)
+    # Raumname
     - label:
         id: ha_sensor_label_${temp}
         grid_cell_column_pos: 1
@@ -56,8 +56,8 @@ obj:
         grid_cell_x_align: START
         grid_cell_y_align: CENTER
         text: !lambda |-
-          if (id(ha_entity_${temp}_friendly_name).has_state()) {
-            return id(ha_entity_${temp}_friendly_name).state;
+          if (id(ha_entity_${temp}_room).has_state()) {
+            return id(ha_entity_${temp}_room).state;
           }
           return std::string("Sensor ${temp}");
         text_font: roboto16

--- a/src/templates/ha_temp_sensor.yaml
+++ b/src/templates/ha_temp_sensor.yaml
@@ -2,7 +2,7 @@
 # Spezielles Template für Temperatur-Sensoren mit dynamischer Icon-Farbe
 # basierend auf dem Temperaturwert
 #
-# Variablen: num, entity_id
+# Variablen: num, entity_id, room
 # Liefert: State-Text, Domain, Friendly Name, Unit of Measurement
 # Aktualisiert: temp_icon_${num} mit temperaturabhängiger Farbe
 #

--- a/src/templates/ha_temp_sensor.yaml
+++ b/src/templates/ha_temp_sensor.yaml
@@ -114,4 +114,3 @@ text_sensor:
         - lvgl.label.update:
             id: ha_sensor_label_${num}
             text: !lambda return x.c_str();
-      

--- a/src/templates/ha_temp_sensor.yaml
+++ b/src/templates/ha_temp_sensor.yaml
@@ -15,6 +15,7 @@
 defaults:
   num: "8"
   entity_id: "sensor.placeholder"
+  room: "Raum"
 
 text_sensor:
   # Unit of Measurement (Einheit aus Home Assistant)
@@ -91,11 +92,6 @@ text_sensor:
     entity_id: ${entity_id}
     attribute: friendly_name
     internal: true
-    on_value:
-      then:
-        - lvgl.label.update:
-            id: ha_sensor_label_${num}
-            text: !lambda return x.c_str();
 
   # Domain (extrahiert aus entity_id)
   - platform: template
@@ -108,3 +104,14 @@ text_sensor:
         return entity_id.substr(0, pos);
       }
       return std::string("unknown");
+
+  - platform: template
+    id: ha_entity_${num}_room
+    internal: true
+    lambda: 'return std::string("${room}");'
+    on_value:
+      then:
+        - lvgl.label.update:
+            id: ha_sensor_label_${num}
+            text: !lambda return x.c_str();
+      


### PR DESCRIPTION
## Beschreibung

Behebt einen Bug, bei dem die Raumnamen in den Temperatur-Cards nicht angezeigt wurden.

## Problem

Der `ha_entity_${num}_room` Text-Sensor in `ha_temp_sensor.yaml` hatte keine `lambda` definiert - nur einen `on_value` Handler, der nie ausgelöst wurde, da kein Initialwert gesetzt war.

## Lösung

- Lambda zu `ha_entity_room` Text-Sensor hinzugefügt für Initialwert
- `ha_temp.yaml` korrigiert um `ha_entity_room.state` korrekt zu verwenden
- Raumnamen werden jetzt beim Boot korrekt angezeigt

## Änderungen

- `src/templates/ha_temp_sensor.yaml`: Lambda für Initialwert hinzugefügt
- `src/templates/ha_temp.yaml`: Referenz auf room text_sensor korrigiert
- `src/common/homeassistant.yaml`: Anpassungen für Template-Nutzung