### PR TITLE
chore: Update ESPHome version to 2026.1.2 in publish workflow

### DIFF
--- a/.github/workflows/publish-firmware.yml
+++ b/.github/workflows/publish-firmware.yml
@@ -15,7 +15,7 @@ jobs:
       #### Modify below here to match your project ####
       files: |
         src/main.yaml
-      esphome-version: 2026.1.1
+      esphome-version: 2026.1.2
       #### Modify above here to match your project ####
 
       release-summary: ${{ github.event.release.body }}


### PR DESCRIPTION
## Änderungen

- Aktualisiert ESPHome-Version von `2026.1.1` auf `2026.1.2` im `publish-firmware.yml` Workflow

## Grund

Hält die CI/CD-Pipeline mit der aktuellen ESPHome-Version synchron.

## Checklist

- [x] ESPHome-Version in `.github/workflows/publish-firmware.yml` aktualisiert
- [x] Änderung ist getestet (CI-Workflow wird beim Merge ausgeführt)