### PR TITLE
feat: EV Charging Page mit Lock, Ladeleistung und Ladestrom-Slider

### DIFF
--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -249,6 +249,9 @@
   size: 24
   bpp: 4
   glyphs: [
+    "\U000F0045", # arrow-down
+    "\U000F005D", # arrow-up
+    "\U000F0156", # close
     "\U000F07D0", # home assistant
     "\U000F15FA", # windsock
     "\U000F068A", # shield home
@@ -305,6 +308,8 @@
   size: 28
   bpp: 4
   glyphs: [
+    "\U000F033E", # lock
+    "\U000F033F", # lock-open
     "\U000F0238", # heat
     "\U000F0717", # cool
     "\U000F1A79", # heat_cool
@@ -363,6 +368,7 @@
     "\U000F1480", # current
     "\U000F095B", # voltage
     "\U000F0425", # power
+    "\U000F05F1", # ev-station
     "\U000F068A", # shield home
     "\U000F1828", # shield moon
     "\U000F099D", # shield lock
@@ -393,6 +399,9 @@
   size: 52
   bpp: 4
   glyphs: [
+    "\U000F033E", # lock
+    "\U000F033F", # lock-open
+    "\U000F050F", # thermometer
     "\U000F068A", # shield home
     "\U000F1828", # shield moon
     "\U000F099D", # shield lock
@@ -418,7 +427,7 @@
   bpp: 4
   glyphsets:
     - GF_Latin_Kernel
-  glyphs: "äöüÄÖÜß°"
+  glyphs: "äöüÄÖÜßØ°"
 
 - file: "gfonts://Roboto"
   id: roboto24

--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -427,7 +427,7 @@
   bpp: 4
   glyphsets:
     - GF_Latin_Kernel
-  glyphs: "äöüÄÖÜßØ°" # Ø (Buchstabe U+00D8) absichtlich für zukünftige Temperatur-Statistik-Widgets als Durchschnitts-Symbol hinzugefügt
+  glyphs: "äöüÄÖÜßØ°" # Ø (U+00D8) als Durchschnitts-Symbol für Temperatur-Statistik-Widgets
 
 - file: "gfonts://Roboto"
   id: roboto24

--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -427,7 +427,7 @@
   bpp: 4
   glyphsets:
     - GF_Latin_Kernel
-  glyphs: "äöüÄÖÜßØ°"
+  glyphs: "äöüÄÖÜßØ°" # Ø hinzugefügt für zukünftige Temperatur Statistik widgets 
 
 - file: "gfonts://Roboto"
   id: roboto24

--- a/src/common/fonts.yaml
+++ b/src/common/fonts.yaml
@@ -427,7 +427,7 @@
   bpp: 4
   glyphsets:
     - GF_Latin_Kernel
-  glyphs: "äöüÄÖÜßØ°" # Ø hinzugefügt für zukünftige Temperatur Statistik widgets 
+  glyphs: "äöüÄÖÜßØ°" # Ø (Buchstabe U+00D8) absichtlich für zukünftige Temperatur-Statistik-Widgets als Durchschnitts-Symbol hinzugefügt
 
 - file: "gfonts://Roboto"
   id: roboto24

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -123,7 +123,7 @@ packages:
       num: "21"
       entity_id: number.wallbox_pulsarplus_sn_107049_garten_maximaler_ladestrom
   ha_ev_sensor_22: !include
-    file: ../templates/ha_sensor.yaml
+    file: ../templates/ha_ev_sensor.yaml
     vars:
       num: "22"
       entity_id: sensor.wallbox_pulsarplus_sn_107049_garten_statusbeschreibung

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -106,3 +106,18 @@ packages:
     vars:
       num: "18"
       entity_id: climate.thermostat_buro
+  ha_lock_19: !include
+    file: ../templates/ha_entity.yaml
+    vars:
+      num: "19"
+      entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+  ha_entity_20: !include
+    file: ../templates/ha_entity.yaml
+    vars:
+      num: "20"
+      entity_id: sensor.wallbox_pulsarplus_sn_107049_garten_ladeleistung
+  ha_number_21: !include
+    file: ../templates/ha_number.yaml
+    vars:
+      num: "21"
+      entity_id: number.wallbox_pulsarplus_sn_107049_garten_maximaler_ladestrom

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -106,13 +106,14 @@ packages:
     vars:
       num: "18"
       entity_id: climate.thermostat_buro
+  # EV Charging Entities (Wallbox) - Verwenden spezielle Templates ohne Switches-Button
   ha_lock_19: !include
-    file: ../templates/ha_entity.yaml
+    file: ../templates/ha_lock.yaml
     vars:
       num: "19"
       entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
-  ha_entity_20: !include
-    file: ../templates/ha_entity.yaml
+  ha_ev_sensor_20: !include
+    file: ../templates/ha_ev_sensor.yaml
     vars:
       num: "20"
       entity_id: sensor.wallbox_pulsarplus_sn_107049_garten_ladeleistung

--- a/src/common/homeassistant.yaml
+++ b/src/common/homeassistant.yaml
@@ -122,3 +122,8 @@ packages:
     vars:
       num: "21"
       entity_id: number.wallbox_pulsarplus_sn_107049_garten_maximaler_ladestrom
+  ha_ev_sensor_22: !include
+    file: ../templates/ha_sensor.yaml
+    vars:
+      num: "22"
+      entity_id: sensor.wallbox_pulsarplus_sn_107049_garten_statusbeschreibung

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -7,6 +7,7 @@ packages:
   switches_page: !include pages/switches.yaml
   temperatures_page: !include pages/temperatures.yaml
   thermostat_page: !include pages/thermostat.yaml
+  ev_charging_page: !include pages/ev_charging.yaml
   ota_page: !include pages/ota.yaml
   navigation: !include pages/navigation.yaml
   theme: !include themes/modern.yaml

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -110,13 +110,13 @@ lvgl:
                                   - homeassistant.action:
                                       action: lock.unlock
                                       data:
-                                        entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                                        entity_id: !lambda return id(ha_entity_19_id).state.c_str();
                                 else:
                                   - logger.log: "Locking wallbox (long press)..."
                                   - homeassistant.action:
                                       action: lock.lock
                                       data:
-                                        entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                                        entity_id: !lambda return id(ha_entity_19_id).state.c_str();
                         widgets:
                           - label:
                               id: ev_lock_btn_icon
@@ -319,7 +319,7 @@ lvgl:
                             - homeassistant.action:
                                 action: number.set_value
                                 data:
-                                  entity_id: !lambda 'return "number.wallbox_pulsarplus_sn_107049_garten_maximaler_ladestrom";'
+                                  entity_id: !lambda return id(ha_number_21_id).state.c_str();
                                   value: !lambda |-
                                     return (int)lv_slider_get_value(id(ha_number_slider_21));
 
@@ -330,6 +330,10 @@ script:
     mode: single
     then:
       - lambda: |-
+          if (!lv_is_initialized()) {
+            return;
+          }
+
           // Lock Status aktualisieren
           std::string lock_state = id(ha_entity_19_state_text).state;
           bool is_locked = (lock_state == "locked");

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -386,4 +386,10 @@ script:
               lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x9CA3AF), LV_PART_MAIN);
               lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
             }
+          } else {
+            // Fallback, wenn der Sensorwert leer oder nicht verfügbar ist
+            lv_label_set_text(id(ev_power_value), "-- W");
+            lv_label_set_text(id(ev_charging_status), "Nicht verfügbar");
+            lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x9CA3AF), LV_PART_MAIN);
+            lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
           }

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -334,12 +334,11 @@ script:
             return;
           }
 
-          // Lock Status aktualisieren
+          // Lock Status aktualisieren (mit expliziter Behandlung aller möglichen Stati)
           std::string lock_state = id(ha_entity_19_state_text).state;
-          bool is_locked = (lock_state == "locked");
           
-          // Icon und Farbe basierend auf Lock-Status
-          if (is_locked) {
+          // Explizite Behandlung für alle Home Assistant Lock-Stati
+          if (lock_state == "locked") {
             // Locked = Orange (Hinweis: halten zum Entsperren)
             lv_label_set_text(id(ev_lock_status_text), "Gesperrt (halten)");
             lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0xF59E0B), LV_PART_MAIN);
@@ -347,7 +346,8 @@ script:
             lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0xF59E0B), LV_PART_MAIN);
             lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0xF59E0B), LV_PART_MAIN);
             lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0xF59E0B), LV_PART_MAIN);
-          } else {
+            lv_obj_clear_state(id(ev_lock_button), LV_STATE_DISABLED);
+          } else if (lock_state == "unlocked") {
             // Unlocked = Grün (Hinweis: halten zum Sperren)
             lv_label_set_text(id(ev_lock_status_text), "Entsperrt (halten)");
             lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0x10B981), LV_PART_MAIN);
@@ -355,6 +355,46 @@ script:
             lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0x10B981), LV_PART_MAIN);
             lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0x10B981), LV_PART_MAIN);
             lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0x10B981), LV_PART_MAIN);
+            lv_obj_clear_state(id(ev_lock_button), LV_STATE_DISABLED);
+          } else if (lock_state == "locking") {
+            // Locking (intermediate state) = Blau
+            lv_label_set_text(id(ev_lock_status_text), "Wird gesperrt...");
+            lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_label_set_text(id(ev_lock_btn_icon), "\U000F033E");
+            lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_obj_add_state(id(ev_lock_button), LV_STATE_DISABLED);
+          } else if (lock_state == "unlocking") {
+            // Unlocking (intermediate state) = Blau
+            lv_label_set_text(id(ev_lock_status_text), "Wird entsperrt...");
+            lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_label_set_text(id(ev_lock_btn_icon), "\U000F033F");
+            lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            lv_obj_add_state(id(ev_lock_button), LV_STATE_DISABLED);
+          } else if (lock_state == "jammed") {
+            // Jammed (error state) = Rot
+            lv_label_set_text(id(ev_lock_status_text), "Blockiert!");
+            lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0xEF4444), LV_PART_MAIN);
+            lv_label_set_text(id(ev_lock_btn_icon), "\U000F0026"); // alert icon
+            lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0xEF4444), LV_PART_MAIN);
+            lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0xEF4444), LV_PART_MAIN);
+            lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0xEF4444), LV_PART_MAIN);
+            lv_obj_add_state(id(ev_lock_button), LV_STATE_DISABLED);
+          } else {
+            // Unknown, unavailable oder andere Stati = Grau
+            const char* status_text = (lock_state == "unavailable") ? "Nicht verfügbar" : 
+                                      (lock_state == "unknown") ? "Status unbekannt" : 
+                                      "Fehler";
+            lv_label_set_text(id(ev_lock_status_text), status_text);
+            lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0x6B7280), LV_PART_MAIN);
+            lv_label_set_text(id(ev_lock_btn_icon), "\U000F02FC"); // info icon
+            lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0x6B7280), LV_PART_MAIN);
+            lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0x6B7280), LV_PART_MAIN);
+            lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0x6B7280), LV_PART_MAIN);
+            lv_obj_add_state(id(ev_lock_button), LV_STATE_DISABLED);
           }
           
           // Ladeleistung aktualisieren

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -10,14 +10,6 @@ lvgl:
     - id: ev_charging_page
       bg_color: color_bg_dark
       widgets:
-        # Hidden placeholders für ha_sensor Template (Sensor 22 - Statusbeschreibung)
-        - label:
-            id: ha_temp_value_22
-            hidden: true
-        - label:
-            id: ha_sensor_label_22
-            hidden: true
-        
         # Hauptcontainer
         - obj:
             layout:

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -10,6 +10,14 @@ lvgl:
     - id: ev_charging_page
       bg_color: color_bg_dark
       widgets:
+        # Hidden placeholders für ha_sensor Template (Sensor 22 - Statusbeschreibung)
+        - label:
+            id: ha_temp_value_22
+            hidden: true
+        - label:
+            id: ha_sensor_label_22
+            hidden: true
+        
         # Hauptcontainer
         - obj:
             layout:
@@ -399,8 +407,8 @@ script:
           
           // Ladeleistung aktualisieren
           std::string power_str = id(ha_entity_20_state_text).state;
+          float power = 0;
           if (!power_str.empty()) {
-            float power = 0;
             // Parse ohne try/catch (ESP-IDF hat exceptions deaktiviert)
             char* end_ptr = nullptr;
             power = strtof(power_str.c_str(), &end_ptr);
@@ -415,21 +423,91 @@ script:
               snprintf(buf, sizeof(buf), "%.0f W", power);
             }
             lv_label_set_text(id(ev_power_value), buf);
-            
-            // Status-Text basierend auf Leistung
-            if (power > 0) {
-              lv_label_set_text(id(ev_charging_status), "Lädt...");
-              lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x10B981), LV_PART_MAIN);
-              lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x10B981), LV_PART_MAIN);
-            } else {
-              lv_label_set_text(id(ev_charging_status), "Bereit");
-              lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x9CA3AF), LV_PART_MAIN);
-              lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
-            }
           } else {
-            // Fallback, wenn der Sensorwert leer oder nicht verfügbar ist
             lv_label_set_text(id(ev_power_value), "-- W");
-            lv_label_set_text(id(ev_charging_status), "Nicht verfügbar");
-            lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x9CA3AF), LV_PART_MAIN);
-            lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
           }
+          
+          // Status-Text aus Sensor ha_entity_22 (Statusbeschreibung)
+          std::string charger_status = id(ha_entity_22_state_text).state;
+          const char* status_text = "Unbekannt";
+          uint32_t status_color = 0x9CA3AF;  // Grau als Default
+          uint32_t icon_color = 0x60A5FA;    // Blau als Default
+          
+          // Status-Übersetzung Englisch → Deutsch mit Farbcodierung
+          if (charger_status == "Charging") {
+            status_text = "Lädt";
+            status_color = 0x10B981;  // Grün
+            icon_color = 0x10B981;
+          } else if (charger_status == "Discharging") {
+            status_text = "Entlädt";
+            status_color = 0xF59E0B;  // Orange
+            icon_color = 0xF59E0B;
+          } else if (charger_status == "Paused") {
+            status_text = "Pausiert";
+            status_color = 0xF59E0B;  // Orange
+            icon_color = 0xF59E0B;
+          } else if (charger_status == "Scheduled") {
+            status_text = "Geplant";
+            status_color = 0x60A5FA;  // Blau
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Waiting for car demand") {
+            status_text = "Warte auf Fahrzeug";
+            status_color = 0x60A5FA;  // Blau
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Waiting") {
+            status_text = "Warte";
+            status_color = 0x60A5FA;  // Blau
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Disconnected") {
+            status_text = "Nicht verbunden";
+            status_color = 0x9CA3AF;  // Grau
+            icon_color = 0x6B7280;
+          } else if (charger_status == "Error") {
+            status_text = "Fehler";
+            status_color = 0xEF4444;  // Rot
+            icon_color = 0xEF4444;
+          } else if (charger_status == "Ready") {
+            status_text = "Bereit";
+            status_color = 0x10B981;  // Grün
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Locked") {
+            status_text = "Gesperrt";
+            status_color = 0xF59E0B;  // Orange
+            icon_color = 0xF59E0B;
+          } else if (charger_status == "Locked, car connected") {
+            status_text = "Gesperrt, Fahrzeug verbunden";
+            status_color = 0xF59E0B;  // Orange
+            icon_color = 0xF59E0B;
+          } else if (charger_status == "Updating") {
+            status_text = "Aktualisiert";
+            status_color = 0x60A5FA;  // Blau
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Waiting in queue by Power Sharing") {
+            status_text = "Warte (Power Sharing)";
+            status_color = 0x60A5FA;  // Blau
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Waiting in queue by Power Boost") {
+            status_text = "Warte (Power Boost)";
+            status_color = 0x60A5FA;  // Blau
+            icon_color = 0x60A5FA;
+          } else if (charger_status == "Waiting MID failed") {
+            status_text = "Warte (MID Fehler)";
+            status_color = 0xEF4444;  // Rot
+            icon_color = 0xEF4444;
+          } else if (charger_status == "Waiting MID safety margin exceeded") {
+            status_text = "Warte (MID Sicherheit)";
+            status_color = 0xF59E0B;  // Orange
+            icon_color = 0xF59E0B;
+          } else if (charger_status == "Waiting in queue by Eco-Smart") {
+            status_text = "Warte (Eco-Smart)";
+            status_color = 0x10B981;  // Grün (Eco = umweltfreundlich)
+            icon_color = 0x10B981;
+          } else if (charger_status == "Unknown" || charger_status == "unavailable" || charger_status.empty()) {
+            status_text = "Unbekannt";
+            status_color = 0x6B7280;  // Dunkelgrau
+            icon_color = 0x6B7280;
+          }
+          
+          lv_label_set_text(id(ev_charging_status), status_text);
+          lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(status_color), LV_PART_MAIN);
+          lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(icon_color), LV_PART_MAIN);

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -1,0 +1,385 @@
+# ========================================================================
+# EV CHARGING PAGE - Wallbox/Ladestation Steuerung
+# ========================================================================
+# Design-Konzept: Zentrale Ladeleistungs-Anzeige, Lock-Status mit
+# Farbcodierung (orange=locked, grün=unlocked), Slider für Ladestrom
+# ========================================================================
+
+lvgl:
+  pages:
+    - id: ev_charging_page
+      bg_color: color_bg_dark
+      widgets:
+        # Hauptcontainer
+        - obj:
+            layout:
+              type: GRID
+              grid_columns: [FR(1)]
+              grid_rows: [80, FR(1), 140]
+              pad_row: 16
+            width: 100%
+            height: ${content_height}
+            pad_all: 20
+            pad_top: 16
+            bg_opa: TRANSP
+            border_opa: TRANSP
+            scrollbar_mode: "OFF"
+            widgets:
+              # ============================================================
+              # TOP ROW - Lock Status Card
+              # ============================================================
+              - obj:
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 0
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 20
+                  bg_color: color_gray_800
+                  bg_opa: 60%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 25%
+                  shadow_width: 12
+                  shadow_ofs_y: 4
+                  shadow_color: color_black
+                  shadow_opa: 30%
+                  pad_all: 12
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [FR(1), SIZE_CONTENT]
+                    grid_rows: [FR(1)]
+                    pad_column: 12
+                  widgets:
+                    # Lock Info (links)
+                    - obj:
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: START
+                        grid_cell_y_align: CENTER
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        width: SIZE_CONTENT
+                        height: SIZE_CONTENT
+                        layout:
+                          type: FLEX
+                          flex_flow: COLUMN
+                          flex_align_main: CENTER
+                          flex_align_cross: START
+                          pad_row: 2
+                        widgets:
+                          # Lock Label
+                          - label:
+                              id: ev_lock_label
+                              text: "Wallbox"
+                              text_font: roboto24
+                              text_color: color_white
+                          # Lock Status Text (inkl. Hinweis auf Long-Press)
+                          - label:
+                              id: ev_lock_status_text
+                              text: "Gesperrt (halten)"
+                              text_font: roboto16
+                              text_color: color_warning
+                    
+                    # Lock Toggle Button (rechts)
+                    # Long-Press (500ms) für Sicherheit bei kritischen Aktionen
+                    - button:
+                        id: ev_lock_button
+                        grid_cell_column_pos: 1
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: END
+                        grid_cell_y_align: CENTER
+                        width: 56
+                        height: 56
+                        radius: 16
+                        bg_color: color_gray_700
+                        bg_opa: 70%
+                        border_color: color_warning
+                        border_width: 2
+                        border_opa: 80%
+                        shadow_width: 8
+                        shadow_color: color_warning
+                        shadow_opa: 30%
+                        on_long_press:
+                          then:
+                            - if:
+                                condition:
+                                  lambda: 'return id(ha_entity_19_state_text).state == "locked";'
+                                then:
+                                  - logger.log: "Unlocking wallbox (long press)..."
+                                  - homeassistant.action:
+                                      action: lock.unlock
+                                      data:
+                                        entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                                else:
+                                  - logger.log: "Locking wallbox (long press)..."
+                                  - homeassistant.action:
+                                      action: lock.lock
+                                      data:
+                                        entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                        widgets:
+                          - label:
+                              id: ev_lock_btn_icon
+                              align: CENTER
+                              text: "\U000F033E"
+                              text_font: mdi_icons_28
+                              text_color: color_warning
+
+              # ============================================================
+              # CENTER ROW - Ladeleistung Anzeige (Hero Element)
+              # ============================================================
+              - obj:
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 1
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 24
+                  bg_color: color_gray_800
+                  bg_opa: 55%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 20%
+                  shadow_width: 16
+                  shadow_ofs_y: 6
+                  shadow_color: color_black
+                  shadow_opa: 35%
+                  pad_all: 16
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [FR(1)]
+                    grid_rows: [SIZE_CONTENT, FR(1), SIZE_CONTENT]
+                    pad_row: 8
+                  widgets:
+                    # Titel
+                    - label:
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: CENTER
+                        grid_cell_y_align: START
+                        text: "Aktuelle Ladeleistung"
+                        text_font: roboto16
+                        text_color: color_gray_400
+                    
+                    # Großer Leistungswert (Hero)
+                    - obj:
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 1
+                        grid_cell_x_align: STRETCH
+                        grid_cell_y_align: CENTER
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        width: 100%
+                        height: SIZE_CONTENT
+                        layout:
+                          type: GRID
+                          grid_columns: [SIZE_CONTENT, FR(1)]
+                          grid_rows: [FR(1)]
+                          pad_column: 16
+                        widgets:
+                          # EV Charging Icon (links)
+                          - label:
+                              id: ev_charging_icon
+                              grid_cell_column_pos: 0
+                              grid_cell_row_pos: 0
+                              grid_cell_x_align: START
+                              grid_cell_y_align: CENTER
+                              text: "\U000F05F1"
+                              text_font: mdi_icons_40
+                              text_color: color_primary_light
+                          # Leistungswert (rechts)
+                          - label:
+                              id: ev_power_value
+                              grid_cell_column_pos: 1
+                              grid_cell_row_pos: 0
+                              grid_cell_x_align: END
+                              grid_cell_y_align: CENTER
+                              text: "0 W"
+                              text_font: roboto40
+                              text_color: color_white
+                    
+                    # Status-Text (lädt / pausiert / nicht verbunden)
+                    - label:
+                        id: ev_charging_status
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 2
+                        grid_cell_x_align: CENTER
+                        grid_cell_y_align: END
+                        text: "Nicht verbunden"
+                        text_font: roboto16
+                        text_color: color_gray_400
+
+              # ============================================================
+              # BOTTOM ROW - Ladestrom Slider
+              # ============================================================
+              - obj:
+                  grid_cell_column_pos: 0
+                  grid_cell_row_pos: 2
+                  grid_cell_x_align: STRETCH
+                  grid_cell_y_align: STRETCH
+                  radius: 20
+                  bg_color: color_gray_800
+                  bg_opa: 60%
+                  border_color: color_gray_600
+                  border_width: 1
+                  border_opa: 25%
+                  shadow_width: 12
+                  shadow_ofs_y: 4
+                  shadow_color: color_black
+                  shadow_opa: 30%
+                  pad_all: 16
+                  scrollbar_mode: "OFF"
+                  layout:
+                    type: GRID
+                    grid_columns: [FR(1)]
+                    grid_rows: [SIZE_CONTENT, SIZE_CONTENT, FR(1)]
+                    pad_row: 0
+                  widgets:
+                    # Slider Header
+                    - obj:
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 0
+                        grid_cell_x_align: STRETCH
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        height: SIZE_CONTENT
+                        layout:
+                          type: GRID
+                          grid_columns: [FR(1)]
+                          grid_rows: [FR(1)]
+                        widgets:
+                          # Label mit Wert
+                          - label:
+                              id: ha_number_label_21
+                              grid_cell_column_pos: 0
+                              grid_cell_row_pos: 0
+                              grid_cell_x_align: CENTER
+                              grid_cell_y_align: CENTER
+                              text: "Max. Ladestrom: -- A"
+                              text_font: roboto16
+                              text_color: color_gray_400
+                    
+                    # Min/Max Labels
+                    - obj:
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 1
+                        grid_cell_x_align: STRETCH
+                        y: -8
+                        bg_opa: TRANSP
+                        border_opa: TRANSP
+                        height: SIZE_CONTENT
+                        layout:
+                          type: GRID
+                          grid_columns: [FR(1), FR(1)]
+                          grid_rows: [FR(1)]
+                        widgets:
+                          - label:
+                              id: ev_slider_min_label
+                              grid_cell_column_pos: 0
+                              grid_cell_row_pos: 0
+                              grid_cell_x_align: START
+                              text: "6 A"
+                              text_font: roboto16
+                              text_color: color_gray_500
+                          - label:
+                              id: ev_slider_max_label
+                              grid_cell_column_pos: 1
+                              grid_cell_row_pos: 0
+                              grid_cell_x_align: END
+                              text: "32 A"
+                              text_font: roboto16
+                              text_color: color_gray_500
+                    
+                    # Slider
+                    - slider:
+                        id: ha_number_slider_21
+                        grid_cell_column_pos: 0
+                        grid_cell_row_pos: 2
+                        grid_cell_x_align: STRETCH
+                        grid_cell_y_align: CENTER
+                        width: 100%
+                        height: 24
+                        min_value: 6
+                        max_value: 32
+                        value: 16
+                        indicator:
+                          bg_color: color_primary
+                          bg_grad_color: color_primary_light
+                          bg_grad_dir: HOR
+                        knob:
+                          radius: 999
+                          width: 32
+                          height: 32
+                          bg_color: color_white
+                          shadow_width: 8
+                          shadow_color: color_black
+                          shadow_opa: 40%
+                        on_release:
+                          then:
+                            - homeassistant.action:
+                                action: number.set_value
+                                data:
+                                  entity_id: !lambda 'return "number.wallbox_pulsarplus_sn_107049_garten_maximaler_ladestrom";'
+                                  value: !lambda |-
+                                    return (int)lv_slider_get_value(id(ha_number_slider_21));
+
+# Scripts für EV Charging Page
+script:
+  # UI Update Script für EV Charging
+  - id: ev_charging_update_ui
+    mode: single
+    then:
+      - lambda: |-
+          // Lock Status aktualisieren
+          std::string lock_state = id(ha_entity_19_state_text).state;
+          bool is_locked = (lock_state == "locked");
+          
+          // Icon und Farbe basierend auf Lock-Status
+          if (is_locked) {
+            // Locked = Orange (Hinweis: halten zum Entsperren)
+            lv_label_set_text(id(ev_lock_status_text), "Gesperrt (halten)");
+            lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0xF59E0B), LV_PART_MAIN);
+            lv_label_set_text(id(ev_lock_btn_icon), "\U000F033E");
+            lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0xF59E0B), LV_PART_MAIN);
+            lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0xF59E0B), LV_PART_MAIN);
+            lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0xF59E0B), LV_PART_MAIN);
+          } else {
+            // Unlocked = Grün (Hinweis: halten zum Sperren)
+            lv_label_set_text(id(ev_lock_status_text), "Entsperrt (halten)");
+            lv_obj_set_style_text_color(id(ev_lock_status_text), lv_color_hex(0x10B981), LV_PART_MAIN);
+            lv_label_set_text(id(ev_lock_btn_icon), "\U000F033F");
+            lv_obj_set_style_text_color(id(ev_lock_btn_icon), lv_color_hex(0x10B981), LV_PART_MAIN);
+            lv_obj_set_style_border_color(id(ev_lock_button), lv_color_hex(0x10B981), LV_PART_MAIN);
+            lv_obj_set_style_shadow_color(id(ev_lock_button), lv_color_hex(0x10B981), LV_PART_MAIN);
+          }
+          
+          // Ladeleistung aktualisieren
+          std::string power_str = id(ha_entity_20_state_text).state;
+          if (!power_str.empty()) {
+            float power = 0;
+            // Parse ohne try/catch (ESP-IDF hat exceptions deaktiviert)
+            char* end_ptr = nullptr;
+            power = strtof(power_str.c_str(), &end_ptr);
+            if (end_ptr == power_str.c_str()) {
+              power = 0;  // Parsing fehlgeschlagen
+            }
+            
+            char buf[32];
+            if (power >= 1000) {
+              snprintf(buf, sizeof(buf), "%.1f kW", power / 1000.0);
+            } else {
+              snprintf(buf, sizeof(buf), "%.0f W", power);
+            }
+            lv_label_set_text(id(ev_power_value), buf);
+            
+            // Status-Text basierend auf Leistung
+            if (power > 0) {
+              lv_label_set_text(id(ev_charging_status), "Lädt...");
+              lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x10B981), LV_PART_MAIN);
+              lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x10B981), LV_PART_MAIN);
+            } else {
+              lv_label_set_text(id(ev_charging_status), "Bereit");
+              lv_obj_set_style_text_color(id(ev_charging_status), lv_color_hex(0x9CA3AF), LV_PART_MAIN);
+              lv_obj_set_style_text_color(id(ev_charging_icon), lv_color_hex(0x60A5FA), LV_PART_MAIN);
+            }
+          }

--- a/src/pages/navigation.yaml
+++ b/src/pages/navigation.yaml
@@ -16,7 +16,7 @@ globals:
   - id: total_pages
     type: int
     restore_value: no
-    initial_value: '4'
+    initial_value: '5'
 
 lvgl:
   top_layer:
@@ -182,12 +182,21 @@ script:
                                   id: page_name_label
                                   text: "Schalter"
                             else:
-                              # Fallback: Zurück zur Home-Seite
-                              - lambda: 'id(current_page_index) = 0;'
-                              - lvgl.page.show: home_page
-                              - lvgl.label.update:
-                                  id: page_name_label
-                                  text: "Home"
+                              - if:
+                                  condition:
+                                    lambda: 'return id(current_page_index) == 4;'
+                                  then:
+                                    - lvgl.page.show: ev_charging_page
+                                    - lvgl.label.update:
+                                        id: page_name_label
+                                        text: "E-Auto Laden"
+                                  else:
+                                    # Fallback: Zurück zur Home-Seite
+                                    - lambda: 'id(current_page_index) = 0;'
+                                    - lvgl.page.show: home_page
+                                    - lvgl.label.update:
+                                        id: page_name_label
+                                        text: "Home"
 # Navigation Bar ein-/ausblenden
   - id: show_navigation
     then:

--- a/src/pages/switches.yaml
+++ b/src/pages/switches.yaml
@@ -9,12 +9,6 @@ lvgl:
     - id: switches_page
       bg_color: color_bg_dark
       widgets:
-        # Hintergrundbild (dynamisch basierend auf Jahreszeit, Default: Sommer)
-        - image:
-            id: switches_bg_image
-            align: CENTER
-            src: see_summer_img
-
         # Hauptcontainer mit 2x3 Grid
         - obj:
             layout:

--- a/src/pages/temperatures.yaml
+++ b/src/pages/temperatures.yaml
@@ -10,12 +10,6 @@ lvgl:
     - id: temperature_page
       bg_color: color_bg_dark
       widgets:
-        # Hintergrundbild (dynamisch basierend auf Jahreszeit, Default: Sommer)
-        - image:
-            id: temperature_bg_image
-            align: CENTER
-            src: see_summer_img
-        
         # Hidden placeholder für ha_sensor_label_10-16 (wird nur für Templates benötigt aber in der page nicht verwendet)
         - label:
             id: ha_sensor_label_10

--- a/src/templates/ha_ev_sensor.yaml
+++ b/src/templates/ha_ev_sensor.yaml
@@ -11,6 +11,7 @@
 defaults:
   num: "20"
   entity_id: "sensor.placeholder"
+  on_value_script: ev_charging_update_ui
 
 text_sensor:
   # Unit of Measurement (Einheit aus Home Assistant)
@@ -33,7 +34,7 @@ text_sensor:
       then:
         - lambda: |-
             ESP_LOGD("ha_ev_sensor", "Sensor ${num} state: %s", x.c_str());
-        - script.execute: ev_charging_update_ui
+        - script.execute: ${on_value_script}
 
   # Friendly Name
   - platform: homeassistant

--- a/src/templates/ha_ev_sensor.yaml
+++ b/src/templates/ha_ev_sensor.yaml
@@ -1,0 +1,66 @@
+# Template für Home Assistant Sensor Entity auf EV-Charging Seite
+# Spezialisiertes Template für Sensoren ohne Button auf Switches-Seite
+# Variablen: num, entity_id
+#
+# Generierte IDs:
+# - ha_entity_${num}_state_text: Text Sensor für Sensor-Wert
+# - ha_entity_${num}_unit: Text Sensor für Einheit
+# - ha_entity_${num}_friendly_name: Text Sensor für Anzeigename
+# - ha_entity_${num}_icon: Text Sensor für MDI Icon
+
+defaults:
+  num: "20"
+  entity_id: "sensor.placeholder"
+
+text_sensor:
+  # Unit of Measurement (Einheit aus Home Assistant)
+  - platform: homeassistant
+    id: ha_entity_${num}_unit
+    entity_id: ${entity_id}
+    attribute: unit_of_measurement
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_ev_sensor", "Sensor ${num} unit: %s", x.c_str());
+
+  # State Text (Sensor-Wert als String)
+  - platform: homeassistant
+    id: ha_entity_${num}_state_text
+    entity_id: ${entity_id}
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_ev_sensor", "Sensor ${num} state: %s", x.c_str());
+        - script.execute: ev_charging_update_ui
+
+  # Friendly Name
+  - platform: homeassistant
+    id: ha_entity_${num}_friendly_name
+    entity_id: ${entity_id}
+    attribute: friendly_name
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_ev_sensor", "Sensor ${num} name: %s", x.c_str());
+
+  # Icon
+  - platform: homeassistant
+    id: ha_entity_${num}_icon
+    entity_id: ${entity_id}
+    attribute: icon
+    internal: true
+
+  # Entity Domain
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: |-
+      std::string entity_id = "${entity_id}";
+      size_t pos = entity_id.find('.');
+      if (pos != std::string::npos) {
+        return entity_id.substr(0, pos);
+      }
+      return std::string("unknown");

--- a/src/templates/ha_lock.yaml
+++ b/src/templates/ha_lock.yaml
@@ -11,6 +11,7 @@
 defaults:
   num: "19"
   entity_id: "lock.placeholder"
+  on_value_script: ev_charging_update_ui
 
 text_sensor:
   # State Text (locked/unlocked)
@@ -22,7 +23,7 @@ text_sensor:
       then:
         - lambda: |-
             ESP_LOGD("ha_lock", "Lock ${num} state: %s", x.c_str());
-        - script.execute: ev_charging_update_ui
+        - script.execute: ${on_value_script}
 
   # Friendly Name
   - platform: homeassistant

--- a/src/templates/ha_lock.yaml
+++ b/src/templates/ha_lock.yaml
@@ -1,0 +1,74 @@
+# Template für Home Assistant Lock Entity Integration
+# Spezialisiertes Template für Lock-Entities ohne Button auf Switches-Seite
+# Variablen: num, entity_id
+#
+# Generierte IDs:
+# - ha_entity_${num}_state_text: Text Sensor für Lock-Status (locked/unlocked)
+# - ha_entity_${num}_friendly_name: Text Sensor für Anzeigename
+# - ha_entity_${num}_icon: Text Sensor für MDI Icon
+# - ha_entity_${num}_domain: Text Sensor für Entity Domain
+
+defaults:
+  num: "19"
+  entity_id: "lock.placeholder"
+
+text_sensor:
+  # State Text (locked/unlocked)
+  - platform: homeassistant
+    id: ha_entity_${num}_state_text
+    entity_id: ${entity_id}
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_lock", "Lock ${num} state: %s", x.c_str());
+        - script.execute: ev_charging_update_ui
+
+  # Friendly Name
+  - platform: homeassistant
+    id: ha_entity_${num}_friendly_name
+    entity_id: ${entity_id}
+    attribute: friendly_name
+    internal: true
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_lock", "Lock ${num} name: %s", x.c_str());
+        - if:
+            condition:
+              lambda: 'return lv_is_initialized();'
+            then:
+              - lvgl.label.update:
+                  id: ev_lock_label
+                  text: !lambda |-
+                    std::string name = x;
+                    if (name.length() > 21) {
+                      name = name.substr(0, 18) + "...";
+                    }
+                    return name;
+
+  # Icon
+  - platform: homeassistant
+    id: ha_entity_${num}_icon
+    entity_id: ${entity_id}
+    attribute: icon
+    internal: true
+
+  # Entity ID
+  - platform: template
+    id: ha_entity_${num}_id
+    internal: true
+    lambda: |-
+      return {"${entity_id}"};
+
+  # Entity Domain
+  - platform: template
+    id: ha_entity_${num}_domain
+    internal: true
+    lambda: |-
+      std::string entity_id = "${entity_id}";
+      size_t pos = entity_id.find('.');
+      if (pos != std::string::npos) {
+        return entity_id.substr(0, pos);
+      }
+      return std::string("unknown");

--- a/src/templates/ha_number.yaml
+++ b/src/templates/ha_number.yaml
@@ -7,9 +7,7 @@
 # - ha_number_${num}_min: Numeric Sensor für Minimalwert
 # - ha_number_${num}_max: Numeric Sensor für Maximalwert
 # - ha_number_${num}_step: Numeric Sensor für Schrittweite
-# - ha_number_${num}_unit: Text Sensor für Einheit
-# - ha_number_${num}_friendly_name: Text Sensor für Anzeigename
-# - ha_number_${num}_icon: Text Sensor für MDI Icon
+# - ha_number_${num}_id: Text Sensor für Entity ID
 
 defaults:
   num: "1"
@@ -73,12 +71,9 @@ sensor:
 
 # Text Sensors
 text_sensor:
-  # Einheit
-  - platform: homeassistant
-    id: ha_number_${num}_unit
-    entity_id: ${entity_id}
-    attribute: unit_of_measurement
-    on_value:
-      then:
-        - lambda: |-
-            ESP_LOGD("ha_number", "Number ${num} unit: %s", x.c_str());
+  # Entity ID
+  - platform: template
+    id: ha_number_${num}_id
+    internal: true
+    lambda: |-
+      return {"${entity_id}"};

--- a/src/templates/ha_number.yaml
+++ b/src/templates/ha_number.yaml
@@ -1,0 +1,84 @@
+# Template für Home Assistant Number Entity Integration
+# Erstellt Sensoren für Number-Entities mit Slider-Unterstützung
+# Variablen: num, entity_id
+#
+# Generierte IDs:
+# - ha_number_${num}_value: Numeric Sensor für aktuellen Wert
+# - ha_number_${num}_min: Numeric Sensor für Minimalwert
+# - ha_number_${num}_max: Numeric Sensor für Maximalwert
+# - ha_number_${num}_step: Numeric Sensor für Schrittweite
+# - ha_number_${num}_unit: Text Sensor für Einheit
+# - ha_number_${num}_friendly_name: Text Sensor für Anzeigename
+# - ha_number_${num}_icon: Text Sensor für MDI Icon
+
+defaults:
+  num: "1"
+  entity_id: "number.placeholder"
+
+# Numeric Sensors
+sensor:
+  # Aktueller Wert
+  - platform: homeassistant
+    id: ha_number_${num}_value
+    entity_id: ${entity_id}
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_number", "Number ${num} value: %.1f", x);
+        - if:
+            condition:
+              lambda: 'return lv_is_initialized();'
+            then:
+              - lvgl.slider.update:
+                  id: ha_number_slider_${num}
+                  value: !lambda "return (int)x;"
+              - lvgl.label.update:
+                  id: ha_number_label_${num}
+                  text: !lambda |-
+                    char buf[32];
+                    snprintf(buf, sizeof(buf), "Max. Ladestrom: %.0f A", x);
+                    return std::string(buf);
+
+  # Minimalwert
+  - platform: homeassistant
+    id: ha_number_${num}_min
+    entity_id: ${entity_id}
+    attribute: min
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_number", "Number ${num} min: %.1f", x);
+            if (lv_is_initialized()) {
+              lv_slider_set_range(id(ha_number_slider_${num}), (int)x, lv_slider_get_max_value(id(ha_number_slider_${num})));
+            }
+
+  # Maximalwert
+  - platform: homeassistant
+    id: ha_number_${num}_max
+    entity_id: ${entity_id}
+    attribute: max
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_number", "Number ${num} max: %.1f", x);
+            if (lv_is_initialized()) {
+              lv_slider_set_range(id(ha_number_slider_${num}), lv_slider_get_min_value(id(ha_number_slider_${num})), (int)x);
+            }
+
+  # Schrittweite
+  - platform: homeassistant
+    id: ha_number_${num}_step
+    entity_id: ${entity_id}
+    attribute: step
+
+# Text Sensors
+text_sensor:
+  # Einheit
+  - platform: homeassistant
+    id: ha_number_${num}_unit
+    entity_id: ${entity_id}
+    attribute: unit_of_measurement
+    on_value:
+      then:
+        - lambda: |-
+            ESP_LOGD("ha_number", "Number ${num} unit: %s", x.c_str());


### PR DESCRIPTION
- Neue Page ev_charging.yaml mit 3-row Layout
- Lock-Status mit Long-Press Toggle und Farbcodierung (orange=locked, grün=unlocked)
- Zentrale Ladeleistungs-Anzeige mit Auto-kW-Konvertierung
- Ladestrom-Slider mit hardcoded 'A' Unit
- Templates: ha_number.yaml, ha_lock.yaml, ha_ev_sensor.yaml
- Navigation erweitert auf 5 Pages (Index 4: E-Auto Laden)
- MDI Icons hinzugefügt: lock/lock-open (28, 52), ev-station (40)
- Home Assistant Integration für Lock, Sensor und Number Entity
- Hintergrundbilder von switches/temperatures Pages entfernt