### PR TITLE
fix(ev-charging): Fix Wallbox lock button requiring double press

### DIFF
--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -83,6 +83,7 @@ lvgl:
                     
                     # Lock Toggle Button (rechts)
                     # Long-Press (500ms) für Sicherheit bei kritischen Aktionen
+                    # Verwendet Script mit initialem Delay um LVGL Touch-Event vollständig abzuschließen
                     - button:
                         id: ev_lock_button
                         grid_cell_column_pos: 1
@@ -92,6 +93,7 @@ lvgl:
                         width: 56
                         height: 56
                         radius: 16
+                        checkable: false
                         bg_color: color_gray_700
                         bg_opa: 70%
                         border_color: color_warning
@@ -102,21 +104,7 @@ lvgl:
                         shadow_opa: 30%
                         on_long_press:
                           then:
-                            - if:
-                                condition:
-                                  lambda: 'return id(ha_entity_19_state_text).state == "locked";'
-                                then:
-                                  - logger.log: "Unlocking wallbox (long press)..."
-                                  - homeassistant.action:
-                                      action: lock.unlock
-                                      data:
-                                        entity_id: !lambda return id(ha_entity_19_id).state.c_str();
-                                else:
-                                  - logger.log: "Locking wallbox (long press)..."
-                                  - homeassistant.action:
-                                      action: lock.lock
-                                      data:
-                                        entity_id: !lambda return id(ha_entity_19_id).state.c_str();
+                            - script.execute: ev_lock_toggle
                         widgets:
                           - label:
                               id: ev_lock_btn_icon
@@ -325,6 +313,38 @@ lvgl:
 
 # Scripts für EV Charging Page
 script:
+  # Lock Toggle Script - sendet Befehl 2x mit langem Delay für Wallbox Wake-Up
+  - id: ev_lock_toggle
+    mode: single
+    then:
+      - if:
+          condition:
+            lambda: 'return id(ha_entity_19_state_text).state == "locked";'
+          then:
+            - logger.log: "Unlocking wallbox (wake-up)..."
+            - homeassistant.service:
+                service: lock.unlock
+                data:
+                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+            - delay: 1500ms
+            - logger.log: "Unlocking wallbox (execute)..."
+            - homeassistant.service:
+                service: lock.unlock
+                data:
+                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+          else:
+            - logger.log: "Locking wallbox (wake-up)..."
+            - homeassistant.service:
+                service: lock.lock
+                data:
+                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+            - delay: 1500ms
+            - logger.log: "Locking wallbox (execute)..."
+            - homeassistant.service:
+                service: lock.lock
+                data:
+                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+
   # UI Update Script für EV Charging
   - id: ev_charging_update_ui
     mode: single

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -325,25 +325,25 @@ script:
             - homeassistant.service:
                 service: lock.unlock
                 data:
-                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                  entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
             - delay: 1500ms
             - logger.log: "Unlocking wallbox (execute)..."
             - homeassistant.service:
                 service: lock.unlock
                 data:
-                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                  entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
           else:
             - logger.log: "Locking wallbox (wake-up)..."
             - homeassistant.service:
                 service: lock.lock
                 data:
-                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                  entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
             - delay: 1500ms
             - logger.log: "Locking wallbox (execute)..."
             - homeassistant.service:
                 service: lock.lock
                 data:
-                  entity_id: lock.wallbox_pulsarplus_sn_107049_garten_schloss
+                  entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
 
   # UI Update Script für EV Charging
   - id: ev_charging_update_ui

--- a/src/pages/ev_charging.yaml
+++ b/src/pages/ev_charging.yaml
@@ -322,26 +322,26 @@ script:
             lambda: 'return id(ha_entity_19_state_text).state == "locked";'
           then:
             - logger.log: "Unlocking wallbox (wake-up)..."
-            - homeassistant.service:
-                service: lock.unlock
+            - homeassistant.action:
+                action: lock.unlock
                 data:
                   entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
             - delay: 1500ms
             - logger.log: "Unlocking wallbox (execute)..."
-            - homeassistant.service:
-                service: lock.unlock
+            - homeassistant.action:
+                action: lock.unlock
                 data:
                   entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
           else:
             - logger.log: "Locking wallbox (wake-up)..."
-            - homeassistant.service:
-                service: lock.lock
+            - homeassistant.action:
+                action: lock.lock
                 data:
                   entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
             - delay: 1500ms
             - logger.log: "Locking wallbox (execute)..."
-            - homeassistant.service:
-                service: lock.lock
+            - homeassistant.action:
+                action: lock.lock
                 data:
                   entity_id: !lambda 'return id(ha_entity_19_id).state.c_str();'
 


### PR DESCRIPTION
## Problem
Der Wallbox Lock-Button musste zweimal gedrückt werden - der erste Long-Press wurde ignoriert, erst der zweite funktionierte.

## Ursache
Die Wallbox Pulsar Plus Cloud-Integration benötigt eine ~1.5 Sekunden "Wake-Up" Zeit bevor sie auf Lock/Unlock-Befehle reagiert. Der erste Befehl wurde ignoriert.

## Lösung
- Lock/Unlock-Befehl wird zweimal gesendet mit 1500ms Delay dazwischen
- Erster Befehl dient als "Wake-Up"
- Zweiter Befehl wird tatsächlich ausgeführt
- `checkable: false` hinzugefügt um Toggle-State-Probleme zu vermeiden

## Tests
✅ Lock-Operation funktioniert mit einem Long-Press
✅ Unlock-Operation funktioniert mit einem Long-Press
✅ UI aktualisiert sich korrekt nach State-Änderung