### PR TITLE
fix: remove device_class from WiFi Signal Prozent sensor

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -308,6 +308,7 @@ sensor:
     name: "WiFi Signal Prozent"
     id: wifi_signal_percent
     entity_category: "diagnostic"
+    device_class: ""  # Keine device_class, da '%' nicht für signal_strength gültig ist
     update_interval: 30s
     filters:
       - lambda: return min(max(2 * (x + 100.0), 0.0), 100.0);


### PR DESCRIPTION
## Problem
Home Assistant zeigt folgende Warnung:
```
Entity sensor.display_*_wifi_signal_prozent is using native unit of measurement '%' which is not a valid unit for the device class ('signal_strength') it is using; expected one of ['dBm', 'dB']
```

## Lösung
Setze `device_class: ""` explizit für den WiFi Signal Prozent Sensor, da die `wifi_signal` Platform automatisch `signal_strength` als device_class setzt, diese aber nur `dBm` oder `dB` als Einheiten akzeptiert.

## Änderungen
- [src/common/core.yaml](src/common/core.yaml): `device_class: ""` für `wifi_signal_percent` Sensor hinzugefügt