### PR TITLE
BUM Display to 2026.2.4

### DIFF
--- a/src/common/substitutions.yaml
+++ b/src/common/substitutions.yaml
@@ -2,7 +2,7 @@
 display_name:             display01
 display_friendly_name:    Display
 project_name:             tnt_larsn.esphome_display
-version:                  "2026.2.3"
+version:                  "2026.2.4"
 
 timezone:                 "Europe/Berlin"
 display_width:            480


### PR DESCRIPTION
## Kontext
Version in den Substitutions aktualisiert.

## Änderungen
- Anpassung in `src/common/substitutions.yaml`

## Tests
- Nicht ausgeführt (nur Versions-Update)
