### PR TITLE
fix: ESPHome LVGL Wrapper für lv_img_set_src (CI dev Build)

### DIFF
--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -609,7 +609,7 @@ script:
           if (img_src != nullptr) {
             for (auto* img_obj : images) {
               if (img_obj != nullptr) {
-                lv_img_set_src(img_obj, img_src->get_lv_img_dsc());
+                esphome::lvgl::lv_img_set_src(img_obj, img_src);
               }
             }
           }


### PR DESCRIPTION
## Problem

Der CI-Workflow schlug seit einigen Tagen im `dev`-Build-Job fehl, obwohl keine Code-Änderungen vorgenommen wurden:

```
src/common/core.yaml:612:46: error: 'class esphome::image::Image' has no member named 'get_lv_img_dsc'; did you mean 'get_lv_image_dsc'?
```

**Ursache:** Die interne Methode `get_lv_img_dsc()` der ESPHome `Image`-Klasse wurde in der `dev`-Version in `get_lv_image_dsc()` umbenannt. Da der CI-Workflow gegen `stable`, `beta` und `dev` baut und täglich per Cron läuft, trat der Fehler ohne eigene Änderungen auf.

## Lösung

Statt die interne Image-Klassen-Methode direkt aufzurufen, wird jetzt der ESPHome-LVGL-Wrapper verwendet:

```cpp
// Vorher (versionsabhängig)
lv_img_set_src(img_obj, img_src->get_lv_img_dsc());

// Nachher (versionsunabhängig)
esphome::lvgl::lv_img_set_src(img_obj, img_src);
```

Der Wrapper in `lvgl_esphome.h` kapselt den internen Methodenaufruf und wird von ESPHome selbst je Version angepasst — der YAML-Code muss nicht mehr geändert werden.

## Verifizierung

- ✅ Lokaler Clean-Build erfolgreich (ESPHome 2026.3.0)