### PR TITLE
Fix ESPHome 2026.4.0b1 substitutions include handling

### DIFF
--- a/src/common/substitutions.yaml
+++ b/src/common/substitutions.yaml
@@ -1,11 +1,12 @@
-# ALLGEMEINES
-display_name:             display01
-display_friendly_name:    Display
-project_name:             tnt_larsn.esphome_display
-version:                  "2026.2.5"
+substitutions:
+  # ALLGEMEINES
+  display_name:             display01
+  display_friendly_name:    Display
+  project_name:             tnt_larsn.esphome_display
+  version:                  "2026.2.5"
 
-timezone:                 "Europe/Berlin"
-display_width:            480
-display_height:           480
-navigation_bar_height:    60
-content_height:           420 # Berechnete Höhe für Content-Bereich (display_height - navigation_bar_height)
+  timezone:                 "Europe/Berlin"
+  display_width:            480
+  display_height:           480
+  navigation_bar_height:    60
+  content_height:           420 # Berechnete Hoehe fuer Content-Bereich (display_height - navigation_bar_height)

--- a/src/main.yaml
+++ b/src/main.yaml
@@ -1,5 +1,6 @@
 packages: 
   # Include all of the core configuration
+  substitutions_config: !include common/substitutions.yaml
   core: !include common/core.yaml
   homeassistant: !include common/homeassistant.yaml
   boot_screen: !include pages/boot.yaml
@@ -12,6 +13,5 @@ packages:
   navigation: !include pages/navigation.yaml
   theme: !include themes/modern.yaml
 
-substitutions: !include common/substitutions.yaml
 font: !include common/fonts.yaml
 image: !include common/image.yaml


### PR DESCRIPTION
## Hintergrund
ESPHome 2026.4.0b1 bricht beim Laden von src/main.yaml mit TypeError: IncludeFile object is not iterable ab, wenn substitutions direkt per !include gesetzt wird.

## Änderungen
- Verschiebt die Einbindung von common/substitutions.yaml in den packages-Block in src/main.yaml.
- Stellt src/common/substitutions.yaml auf ein package-kompatibles Format mit Top-Level substitutions: um.

## Warum nötig
Die neue/beta ESPHome-Parsing-Logik erwartet an dieser Stelle ein iterierbares Mapping; ein direktes IncludeFile führt zum Crash. Die Umstellung beseitigt den Parserfehler und hält die Konfiguration in 2026.4.0b1 validier- und kompilierbar.

## Verifikation
- Lokaler Compile mit ESPHome 2026.4.0b1 erfolgreich für:
  - src/main.yaml
  - src/main.factory.yaml