### PR TITLE
fix: limit lv_task_handler usage to OTA special case

### DIFF
--- a/scripts/test_ci.py
+++ b/scripts/test_ci.py
@@ -5,6 +5,7 @@ Führt die gleichen Schritte wie .github/workflows/ci.yml aus
 """
 
 import os
+import re
 import subprocess
 import sys
 from pathlib import Path
@@ -122,12 +123,61 @@ def compile_yaml(yaml_file: str) -> bool:
         print_error(f"Fehler beim Ausführen: {str(e)}")
         return False
 
+
+def check_lv_task_handler_usage() -> bool:
+    """Erlaubt lv_task_handler nur im HTTP-OTA on_progress in core.yaml."""
+    core_file = Path('src/common/core.yaml')
+    if not core_file.exists():
+        print_error("src/common/core.yaml nicht gefunden")
+        return False
+
+    content = core_file.read_text(encoding='utf-8')
+    occurrences = [m.start() for m in re.finditer(r'\blv_task_handler\s*\(', content)]
+    if not occurrences:
+        return True
+
+    allowed_block_pattern = re.compile(
+        r'on_progress:\n'
+        r'\s+then:\n'
+        r'(?:\s+- .*\n)*?'
+        r'\s+- lambda: \|-\n'
+        r'(?:\s+.*\n)*?'
+        r'\s+lv_task_handler\(\);\n'
+        r'(?:\s+.*\n)*?'
+        r"\s+- lambda: 'lv_task_handler\(\);'",
+        re.MULTILINE,
+    )
+
+    allowed_regions = [(m.start(), m.end()) for m in allowed_block_pattern.finditer(content)]
+
+    illegal_hits = []
+    for pos in occurrences:
+        if not any(start <= pos < end for start, end in allowed_regions):
+            line_no = content.count('\n', 0, pos) + 1
+            illegal_hits.append(line_no)
+
+    if illegal_hits:
+        print_error("Unerlaubte lv_task_handler()-Verwendung gefunden")
+        for line_no in illegal_hits:
+            print_error(f"src/common/core.yaml:{line_no}")
+        print_warning(
+            "lv_task_handler() ist nur als OTA-Spezialfall im HTTP-OTA on_progress erlaubt."
+        )
+        return False
+
+    print_success("lv_task_handler()-Nutzung ist auf den OTA-Spezialfall begrenzt")
+    return True
+
 def main():
     """Hauptfunktion - führt alle CI-Tests aus"""
     print_header("ESPHome CI Tests (Lokal)")
     
     # Prüfe ob ESPHome installiert ist
     if not check_esphome_installed():
+        sys.exit(1)
+
+    print_header("Prüfe Spezialregel: lv_task_handler")
+    if not check_lv_task_handler_usage():
         sys.exit(1)
     
     # YAML-Dateien aus ci.yml

--- a/scripts/test_ci.sh
+++ b/scripts/test_ci.sh
@@ -34,6 +34,34 @@ print_warning() {
     echo -e "${YELLOW}⚠ $1${NC}"
 }
 
+# lv_task_handler darf nur als OTA-Spezialfall in src/common/core.yaml verwendet werden.
+check_lv_task_handler_usage() {
+    local core_file="src/common/core.yaml"
+    if [ ! -f "$core_file" ]; then
+        print_error "$core_file nicht gefunden!"
+        return 1
+    fi
+
+    local total
+    total=$(grep -n "lv_task_handler()" "$core_file" | wc -l | tr -d ' ')
+    if [ "$total" -eq 0 ]; then
+        print_success "Keine lv_task_handler()-Verwendung gefunden"
+        return 0
+    fi
+
+    local in_ota
+    in_ota=$(grep -n "lv_task_handler()" "$core_file" | grep -E ":48[0-9]:|:49[0-9]:" | wc -l | tr -d ' ')
+    if [ "$total" -ne "$in_ota" ]; then
+        print_error "Unerlaubte lv_task_handler()-Verwendung gefunden"
+        grep -n "lv_task_handler()" "$core_file"
+        print_warning "lv_task_handler() ist nur als OTA-Spezialfall im HTTP-OTA on_progress erlaubt."
+        return 1
+    fi
+
+    print_success "lv_task_handler()-Nutzung ist auf den OTA-Spezialfall begrenzt"
+    return 0
+}
+
 # Prüfe ESPHome
 print_header "ESPHome Version Check"
 if "$ESPHOME" version &> /dev/null; then
@@ -42,6 +70,11 @@ if "$ESPHOME" version &> /dev/null; then
 else
     print_error "ESPHome nicht gefunden!"
     print_warning "Installiere mit: scripts/dev/esphome-env install stable"
+    exit 1
+fi
+
+print_header "Prüfe Spezialregel: lv_task_handler"
+if ! check_lv_task_handler_usage; then
     exit 1
 fi
 

--- a/src/common/core.yaml
+++ b/src/common/core.yaml
@@ -480,6 +480,9 @@ ota:
       then:
         - lambda: |-
             id(ota_progress) = (int)x;
+            // OTA-Ausnahme: Erzwingt UI-Tick waehrend blockierendem OTA-Download.
+            // Nicht als allgemeines LVGL-Muster verwenden.
+            lv_task_handler();
         - lvgl.bar.update:
             id: ota_bar
             value: !lambda "return (int)x;"
@@ -489,6 +492,8 @@ ota:
               char buf[8];
               snprintf(buf, sizeof(buf), "%d %%", (int)x);
               return std::string(buf);
+        # OTA-Ausnahme: zweiter Tick fuer sichtbaren Fortschritt trotz OTA-Blockade.
+        - lambda: 'lv_task_handler();'
     on_end:
       then:
         - lambda: 'id(ota_active) = false;'


### PR DESCRIPTION
## Summary
- keep OTA progress workaround in HTTP OTA callback
- document that lv_task_handler is an OTA-only exception
- add CI guard so lv_task_handler usage outside the allowed OTA block fails tests

## Why
OTA progress needs a forced LVGL tick in this project, but using this pattern broadly is risky and should be prevented.

## Scope
Only staged changes from main were included.